### PR TITLE
Dialog Objects

### DIFF
--- a/fract4d/browser_model.py
+++ b/fract4d/browser_model.py
@@ -99,12 +99,12 @@ class T:
             TypeInfo(self, compiler, fc.FormulaTypes.TRANSFORM),
             TypeInfo(self, compiler, fc.FormulaTypes.GRADIENT)
             ]
+        self.current = None
         self.current_type = -1
         self.type_changed = event.T()
         self.file_changed = event.T()
         self.formula_changed = event.T()
-        self.set_type(FRACTAL)
-        
+
     def formula_type_to_browser_type(self,t):
         if t == fc.FormulaTypes.FRACTAL:
             return FRACTAL

--- a/fract4d/browser_model.py
+++ b/fract4d/browser_model.py
@@ -157,5 +157,3 @@ class T:
 
         r = self.compiler.get_text(fname)
         return r
-        
-instance = T(fc.instance)

--- a/fract4d/cache.py
+++ b/fract4d/cache.py
@@ -33,7 +33,6 @@ class T:
         self.createPickledFile(self._indexName(), self.files)
     
     def clear(self):
-        if not os: return # get 'NoneType not callable' sometimes otherwise, which seems weird
         for f in os.listdir(self.dir):
             try:
                 os.remove(os.path.join(self.dir,f))

--- a/fract4d/fc.py
+++ b/fract4d/fc.py
@@ -493,9 +493,6 @@ class Compiler:
         if not self.leave_dirty:
             self.clear_cache()
 
-instance = Compiler()
-instance.update_from_prefs(fractconfig.instance)
-
 def usage():
     print("FC : a compiler from Fractint .frm files to C code")
     print("fc.py -o [outfile] -f [formula] infile")

--- a/fract4d/test_browser_model.py
+++ b/fract4d/test_browser_model.py
@@ -65,7 +65,8 @@ class Test(testbase.TestBase):
 
     def testSetType(self):
         bm = Wrapper()
-        self.assertEqual([], bm.type_changelist)
+        bm.set_type(browser_model.FRACTAL)
+        self.assertEqual([browser_model.FRACTAL], bm.type_changelist)
         self.assertEqual(browser_model.FRACTAL, bm.current_type)
         self.assertEqual(            
             bm.typeinfo[bm.current_type], bm.current)
@@ -73,11 +74,12 @@ class Test(testbase.TestBase):
         bm.set_type(browser_model.INNER)
         self.assertEqual(browser_model.INNER, bm.current_type)
         self.assertEqual(
-            [browser_model.INNER],
+            [browser_model.FRACTAL, browser_model.INNER],
             bm.type_changelist)
 
     def testFileList(self):
         bm = browser_model.T(g_comp)
+        bm.set_type(browser_model.FRACTAL)
         self.assertNotEqual(bm.current.files, [])
         self.assertListSorted(bm.current.files)
         
@@ -91,6 +93,7 @@ class Test(testbase.TestBase):
 
     def testSetTypeUpdatesFnames(self):
         bm = browser_model.T(g_comp)
+        bm.set_type(browser_model.FRACTAL)
 
         bm.current.fname = "fish"
         bm.current.formula = "haddock"
@@ -107,6 +110,7 @@ class Test(testbase.TestBase):
 
     def testSetFile(self):
         bm = Wrapper()
+        bm.set_type(browser_model.FRACTAL)
         bm.set_file("gf4d.frm")
         self.assertEqual("gf4d.frm",bm.current.fname)
         self.assertEqual(
@@ -116,6 +120,7 @@ class Test(testbase.TestBase):
 
     def testSetBadFile(self):
         bm = browser_model.T(g_comp)
+        bm.set_type(browser_model.FRACTAL)
         self.assertRaises(IOError,bm.set_file,"nonexistent.frm")
 
     def assertListSorted(self,l):
@@ -126,6 +131,7 @@ class Test(testbase.TestBase):
         
     def testFormulasSorted(self):
         bm = browser_model.T(g_comp)
+        bm.set_type(browser_model.FRACTAL)
         bm.set_file("gf4d.frm")
         self.assertListSorted(bm.current.formulas)
         
@@ -141,6 +147,7 @@ class Test(testbase.TestBase):
 
     def testSetFormula(self):
         bm = Wrapper()
+        bm.set_type(browser_model.FRACTAL)
         bm.set_file("gf4d.frm")
         bm.set_formula("Mandelbrot")
         self.assertEqual("Mandelbrot",bm.current.formula)
@@ -149,6 +156,7 @@ class Test(testbase.TestBase):
 
     def testSetFileResetsFormula(self):
         bm = Wrapper()
+        bm.set_type(browser_model.FRACTAL)
         bm.set_file("gf4d.frm")
         bm.set_formula("Mandelbrot")
         bm.set_file("fractint-g4.frm")
@@ -158,7 +166,9 @@ class Test(testbase.TestBase):
 
     def testUpdate(self):
         bm = Wrapper()
-        bm.update("gf4d.frm","Mandelbrot")
+        bm.set_type(browser_model.FRACTAL)
+        bm.set_file("gf4d.frm")
+        bm.set_formula("Mandelbrot")
         self.assertEqual("gf4d.frm",bm.current.fname)
         self.assertEqual("Mandelbrot", bm.current.formula)
 
@@ -172,6 +182,7 @@ class Test(testbase.TestBase):
 
     def testApplyStatus(self):
         bm = browser_model.T(g_comp)
+        bm.set_type(browser_model.FRACTAL)
         self.assertEqual(False, bm.current.can_apply)
 
         bm.set_file("gf4d.frm")
@@ -198,9 +209,7 @@ class Test(testbase.TestBase):
         files = bm.current.files
         self.assertEqual(1,files.count("blatte1.ugr"))
 
-    def testInstance(self):
-        x = browser_model.instance
-        
+
 def suite():
     return unittest.makeSuite(Test,'test')
 

--- a/fract4d/test_fc.py
+++ b/fract4d/test_fc.py
@@ -247,7 +247,8 @@ bailout: abs(real(z)) > 2.0 || abs(imag(z)) > 2.0
         self.assertEqual(["wibble"], compiler.path_lists[3])
         
     def testInstance(self):
-        compiler = fc.instance
+        compiler = fc.Compiler()
+        compiler.update_from_prefs(fractconfig.instance)
         self.assertNotEqual(None, compiler)
         self.assertEqual(
             compiler.flags, fractconfig.instance.get("compiler", "options"))

--- a/fract4dgui/angle.py
+++ b/fract4dgui/angle.py
@@ -35,7 +35,7 @@ class T(Gtk.DrawingArea):
             Gdk.EventMask.BUTTON1_MOTION_MASK |
             Gdk.EventMask.POINTER_MOTION_HINT_MASK |
             Gdk.EventMask.ENTER_NOTIFY_MASK |
-            Gdk.EventMask.LEAVE_NOTIFY_MASK |                               
+            Gdk.EventMask.LEAVE_NOTIFY_MASK |
             Gdk.EventMask.BUTTON_PRESS_MASK |
             Gdk.EventMask.EXPOSURE_MASK
             )
@@ -51,7 +51,7 @@ class T(Gtk.DrawingArea):
         self.adjustment.set_value(val)
         self.queue_draw()
         
-    def update_from_mouse(self,x,y):        
+    def update_from_mouse(self,x,y):
         (w,h) = (self.get_allocated_width(), self.get_allocated_height())
         
         xc = w//2
@@ -74,13 +74,11 @@ class T(Gtk.DrawingArea):
     def onMotionNotify(self,widget,event):
         if not self.notice_mouse:
             return
-        dummy = widget.get_pointer()
         self.update_from_mouse(event.x, event.y)
 
     def onButtonRelease(self,widget,event):
-        if event.button==1:
+        if event.button == 1:
             self.notice_mouse = False
-            (xc,yc) = (widget.get_allocated_width()//2, widget.get_allocated_height()//2)
             current_value = self.adjustment.get_value()
             if self.old_value != current_value:
                 self.old_value = current_value
@@ -88,7 +86,6 @@ class T(Gtk.DrawingArea):
 
         self.set_state(Gtk.StateType.NORMAL)
 
-        
     def onButtonPress(self,widget,event):
         if event.button == 1:
             self.notice_mouse = True

--- a/fract4dgui/autozoom.py
+++ b/fract4dgui/autozoom.py
@@ -7,17 +7,13 @@ from gi.repository import Gtk
 
 from . import dialog
 
-def show_autozoom(parent,f):
-    AutozoomDialog.show(parent,f)
-    
 class AutozoomDialog(dialog.T):
     def __init__(self,main_window,f):
         dialog.T.__init__(
             self,
             _("Autozoom"),
             main_window,
-            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True
+            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
         )
 
         self.f = f
@@ -58,11 +54,8 @@ class AutozoomDialog(dialog.T):
         self.table.attach(self.minsize_entry,
                           1,2,1,2,
                           Gtk.AttachOptions.EXPAND | Gtk.AttachOptions.FILL, 0, 2, 2)
-
-    def show(parent, f):
-        dialog.T.reveal(AutozoomDialog, True, parent, None, f)
-
-    show = staticmethod(show)
+        
+        self.vbox.show_all()
 
     def onResponse(self,widget,id):
         self.zoombutton.set_active(False)

--- a/fract4dgui/browser.py
+++ b/fract4dgui/browser.py
@@ -38,7 +38,7 @@ class BrowserDialog(dialog.T):
 
         self.set_default_response(Gtk.ResponseType.OK)
 
-        self.model = browser_model.instance
+        self.model = browser_model.T(main_window.compiler)
         self.model.type_changed += self.on_type_changed
         self.model.file_changed += self.on_file_changed
         self.model.formula_changed += self.on_formula_changed

--- a/fract4dgui/dialog.py
+++ b/fract4dgui/dialog.py
@@ -2,8 +2,6 @@
 
 from gi.repository import Gtk
 
-_dialogs = {}
-
 def make_label_box(parent, title):
     label_box = Gtk.HBox()
     label_box.set_name('dialog_label_box')
@@ -17,48 +15,18 @@ def make_label_box(parent, title):
     return label_box
 
 class T(Gtk.Dialog):
-    def __init__(self, title=None, parent=None, buttons=None,**kwds):
-        Gtk.Dialog.__init__(self, title=title, transient_for=parent, **kwds)
+    def __init__(self, title=None, parent=None, buttons=None, modal=True):
+        Gtk.Dialog.__init__(self,
+            title=title,
+            transient_for=parent,
+            modal=modal,
+            destroy_with_parent=True)
 
         if buttons:
                 self.add_buttons(*buttons)
 
         self.set_default_response(Gtk.ResponseType.CLOSE)
         self.connect('response',self.onResponse)
-
-        self.connect('destroy-event', self.clear_global)
-        self.connect('delete-event', self.clear_global)
-
-    def clear_global(self,*args):
-        global _dialogs
-        _dialogs[self.__class__] = None
-    
-    def reveal(type, dialog_mode, parent, alt_parent, *args):
-        global _dialogs
-        if not _dialogs.get(type):
-            _dialogs[type] = type(parent, *args)
-        if dialog_mode:
-            _dialogs[type].show_all()
-            _dialogs[type].present()
-        else:
-            if not hasattr(alt_parent, "dialogs"):
-                alt_parent.dialogs = {}
-            container = alt_parent.dialogs.get(type)
-            if not container:                
-                dialog = _dialogs[type]
-                box = dialog.controls
-                title = dialog.get_title()
-                container = make_container(title)
-                box.reparent(container)
-                alt_parent.pack_start(container,True,True,0)
-                alt_parent.dialogs[type] = container
-
-            container.show_all()
-            _dialogs[type].hide()
-        
-        return _dialogs[type]
-    
-    reveal = staticmethod(reveal)
 
     def onResponse(self,widget,id):
         if id == Gtk.ResponseType.CLOSE or \
@@ -67,7 +35,3 @@ class T(Gtk.Dialog):
             self.hide()
         else:
             print("unexpected response %d" % id)
-
-def get(type):
-    global _dialogs
-    return _dialogs.get(type)

--- a/fract4dgui/dialog.py
+++ b/fract4dgui/dialog.py
@@ -4,18 +4,17 @@ from gi.repository import Gtk
 
 _dialogs = {}
 
-def make_container(title):
+def make_label_box(parent, title):
     label_box = Gtk.HBox()
     label_box.set_name('dialog_label_box')
     label = Gtk.Label(label=title)
     label_box.pack_start(label, False, False, 0)
     close = Gtk.Button.new_from_stock(Gtk.STOCK_CLOSE)
     label_box.pack_end(close, False, False, 0)
-    frame = Gtk.VBox()
-    frame.pack_start(label_box, False, False, 1)
+    label_box.show_all()
 
-    close.connect('clicked', lambda x : frame.hide())
-    return frame
+    close.connect('clicked', lambda x : parent.hide())
+    return label_box
 
 class T(Gtk.Dialog):
     def __init__(self, title=None, parent=None, buttons=None,**kwds):

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -20,9 +20,6 @@ from fract4d import animation, fractconfig
 
 from . import PNGGen,AVIGen,DlgAdvOpt,director_prefs
 
-def show(parent,alt_parent, f,dialog_mode,conf_file=""):
-    DirectorDialog.show(parent,alt_parent, f,dialog_mode,conf_file)
-
 class UserCancelledError(Exception):
 	pass
 
@@ -33,11 +30,6 @@ class SanityCheckError(Exception):
 
 class DirectorDialog(dialog.T,hig.MessagePopper):
     RESPONSE_RENDER=1
-    def show(parent, alt_parent, f,dialog_mode,conf_file):
-        dialog.T.reveal(DirectorDialog, dialog_mode,
-                        parent, alt_parent, f,conf_file)
-
-    show = staticmethod(show)
 
     def check_for_keyframe_clash(self,keyframe,fct_dir):
         keydir=os.path.dirname(keyframe)
@@ -445,22 +437,19 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         res=dlg.show()
 
     #creating window...
-    def __init__(self, main_window, f,conf_file):
+    def __init__(self, main_window, f, conf_file=""):
         dialog.T.__init__(
             self,
             _("Director"),
             main_window,
             (_("_Render"), DirectorDialog.RESPONSE_RENDER,
-             Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True)
+             Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
+        )
 
         hig.MessagePopper.__init__(self)
         self.animation=animation.T(f.compiler)
         self.f=f
         self.compiler = f.compiler
-        self.realize()
-
-        self.main_window = main_window
 
         #main VBox
         self.box_main=Gtk.VBox(False,0)
@@ -706,6 +695,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
 
         #--------------showing all-------------------------------
         self.vbox.add(self.box_main)
+        self.vbox.show_all()
         self.controls = self.vbox
         if conf_file!="":
             self.load_configuration(conf_file)

--- a/fract4dgui/fourway.py
+++ b/fract4dgui/fourway.py
@@ -12,12 +12,12 @@ class T(Gtk.DrawingArea):
         None, (GObject.TYPE_INT, GObject.TYPE_INT))
         }
 
-    def __init__(self,text):        
+    def __init__(self,text):
         self.button = 0
         self.radius = 0
         self.last_x = 0
-        self.last_y = 0        
-        self.text=text
+        self.last_y = 0
+        self.text = text
         Gtk.DrawingArea.__init__(self)
 
         self.set_size_request(53,53)
@@ -49,11 +49,10 @@ class T(Gtk.DrawingArea):
     def onMotionNotify(self,widget,event):
         if not self.notice_mouse:
             return
-        dummy = widget.get_pointer()
         self.update_from_mouse(event.x, event.y)
 
     def onButtonRelease(self,widget,event):
-        if event.button==1:
+        if event.button == 1:
             self.notice_mouse = False
             (xc,yc) = (widget.get_allocated_width()//2, widget.get_allocated_height()//2)
             dx = xc - self.last_x
@@ -74,12 +73,10 @@ class T(Gtk.DrawingArea):
     def redraw_rect(self, widget, cairo_ctx):
         style_ctx = widget.get_style_context()
         (w,h) = (widget.get_allocated_width(), widget.get_allocated_height())
-        Gtk.render_background(style_ctx,
-            cairo_ctx, 0, 0, w-1, h-1)
+        Gtk.render_background(style_ctx, cairo_ctx, 0, 0, w-1, h-1)
 
         xc = w//2
         yc = h//2
-        radius = min(w,h)//2 -1
 
         # Consider using gtk_render_arrow
         def triangle(points):
@@ -93,7 +90,7 @@ class T(Gtk.DrawingArea):
         th = 8
         tw = 6
 
-        # Triangle pointing left        
+        # Triangle pointing left
         points = [
             (1, yc),
             (1+th, yc-tw),
@@ -102,23 +99,23 @@ class T(Gtk.DrawingArea):
 
         # pointing right
         points = [
-            (w -2, yc),
-            (w -2 -th, yc-tw),
-            (w -2 -th, yc+tw)]
+            (w-2, yc),
+            (w-2-th, yc-tw),
+            (w-2-th, yc+tw)]
         triangle(points)
 
         # pointing up
         points = [
             (xc, 1),
-            (xc - tw, th),
-            (xc + tw, th)]
+            (xc-tw, th),
+            (xc+tw, th)]
         triangle(points)
         
         # pointing down
         points = [
-            (xc, h - 2),
-            (xc - tw, h - 2 - th),
-            (xc + tw, h - 2 - th)]
+            (xc, h-2),
+            (xc-tw, h-2-th),
+            (xc+tw, h-2-th)]
         triangle(points)
 
         pango_ctx = widget.get_pango_context()
@@ -135,7 +132,7 @@ class T(Gtk.DrawingArea):
             
             (text_width, text_height) = layout.get_pixel_size()
             # truncate text if it's too long
-            if text_width < (w - th *2) or len(drawtext) < 3:
+            if text_width < (w-th*2) or len(drawtext) < 3:
                 break
             drawtext = drawtext[:-1]
 

--- a/fract4dgui/fourway.py
+++ b/fract4dgui/fourway.py
@@ -1,12 +1,8 @@
-# Sort of a widget which controls 2 linear dimensions of the fractal
-# I say sort of, because this doesn't actually inherit from Gtk.Widget,
-# so it's not really a widget. This is because if I attempt to do that
-# pygtk crashes. Hence I delegate to a member which actually is a widget
-# with some stuff drawn on it - basically an ungodly hack.
+# A widget which controls 2 linear dimensions of the fractal
 
 from gi.repository import Gtk, Gdk, GObject, Pango
 
-class T(GObject.GObject):
+class T(Gtk.DrawingArea):
     __gsignals__ = {
         'value-changed' : (
         (GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.NO_RECURSE),
@@ -22,12 +18,11 @@ class T(GObject.GObject):
         self.last_x = 0
         self.last_y = 0        
         self.text=text
-        GObject.GObject.__init__(self)
-        
-        self.widget = Gtk.DrawingArea()
-        self.widget.set_size_request(53,53)
+        Gtk.DrawingArea.__init__(self)
 
-        self.widget.set_events(
+        self.set_size_request(53,53)
+
+        self.set_events(
             Gdk.EventMask.BUTTON_RELEASE_MASK |
             Gdk.EventMask.BUTTON1_MOTION_MASK |
             Gdk.EventMask.POINTER_MOTION_HINT_MASK |
@@ -38,10 +33,10 @@ class T(GObject.GObject):
             )
 
         self.notice_mouse = False
-        self.widget.connect('motion_notify_event', self.onMotionNotify)
-        self.widget.connect('button_release_event', self.onButtonRelease)
-        self.widget.connect('button_press_event', self.onButtonPress)
-        self.widget.connect('draw',self.onDraw)
+        self.connect('motion_notify_event', self.onMotionNotify)
+        self.connect('button_release_event', self.onButtonRelease)
+        self.connect('button_press_event', self.onButtonPress)
+        self.connect('draw',self.onDraw)
         
     def update_from_mouse(self,x,y):
         dx = self.last_x - x
@@ -73,12 +68,6 @@ class T(GObject.GObject):
             self.last_y = widget.get_allocated_height()/2
             self.update_from_mouse(event.x, event.y)
 
-    def __del__(self):
-        #This is truly weird. If I don't have this method, when you use
-        # one fourway widget, it fucks up the other. Having this fixes it.
-        # *even though it doesn't do anything*. Disturbing.
-        pass
-        
     def onDraw(self, widget, cairo_ctx):
         self.redraw_rect(widget, cairo_ctx)
 
@@ -156,7 +145,3 @@ class T(GObject.GObject):
             xc - text_width//2,
             yc - text_height//2,
             layout)
-
-        
-# explain our existence to GTK's object system
-GObject.type_register(T)

--- a/fract4dgui/gtkfractal.py
+++ b/fract4dgui/gtkfractal.py
@@ -690,7 +690,7 @@ class T(Hidden):
         name = self.param_display_name(name,param)
         fway = fourway.T(name)
         tip = self.param_tip(name,param)
-        fway.widget.set_tooltip_text(tip)
+        fway.set_tooltip_text(tip)
         
         fway.connect('value-changed',self.fourway_released, order, form)
 
@@ -699,7 +699,7 @@ class T(Hidden):
                 'value-slightly-changed',
                 self.parent.on_drag_param_fourway, order, param_type)
         
-        table.attach(fway.widget,0,1,i,i+2, Gtk.AttachOptions.EXPAND|Gtk.AttachOptions.FILL,0, 0,0)
+        table.attach(fway,0,1,i,i+2, Gtk.AttachOptions.EXPAND|Gtk.AttachOptions.FILL,0, 0,0)
 
     def fourway_released(self,widget,x,y,order,form):
         form.nudge_param(order, x,y)

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -1002,12 +1002,12 @@ class MainWindow:
         my_angle.axis = axis
 
         self.toolbar.add_widget(
-            my_angle.widget,
+            my_angle,
             tip,
             tip)
 
         if is4dsensitive:
-            self.four_d_sensitives.append(my_angle.widget)
+            self.four_d_sensitives.append(my_angle)
         
     def update_angle_widget(self,f,widget):
         widget.set_value(f.get_param(widget.axis))
@@ -1074,7 +1074,7 @@ class MainWindow:
     def add_fourway(self, name, tip, axis, is4dsensitive):
         my_fourway = fourway.T(name)
         self.toolbar.add_widget(
-            my_fourway.widget,
+            my_fourway,
             tip,
             None)
 
@@ -1084,7 +1084,7 @@ class MainWindow:
         my_fourway.connect('value-changed', self.on_release_fourway)
 
         if is4dsensitive:
-            self.four_d_sensitives.append(my_fourway.widget)
+            self.four_d_sensitives.append(my_fourway)
 
     def update_recent_files(self, file):
         self.recent_files = preferences.userPrefs.update_list("recent_files",file,4)

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -120,7 +120,9 @@ class MainWindow:
         self.saveas_fs = None
         self.saveimage_fs = None
         self.hires_image_fs = None
-        self.open_fs = None        
+        self.open_fs = None
+        
+        self.renderQueue = renderqueue.T()
 
         self.update_subfract_visibility(False)
         self.populate_warpmenu(self.f)
@@ -138,6 +140,7 @@ class MainWindow:
         self.f.set_saved(True)
 
         self.painterDialog = painter.PainterDialog(self.window, self.f)
+        self.renderqueueDialog = renderqueue.QueueDialog(self.window, self.f, self.renderQueue)
 
     def create_rtd_widgets(self):
         table = Gtk.Table(n_rows=2,n_columns=3,homogeneous=False)
@@ -731,9 +734,9 @@ class MainWindow:
         self.painterDialog.show()
 
     def add_to_queue(self,name,w,h):
-        renderqueue.show(self.window,None,self.f)
-        renderqueue.instance.add(self.f.f,name,w,h)
-        renderqueue.instance.start()
+        self.renderqueueDialog.show()
+        self.renderQueue.add(self.f.f,name,w,h)
+        self.renderQueue.start()
         
     def toggle_explorer(self, action):
         """Enter (or leave) Explorer mode."""
@@ -1398,7 +1401,7 @@ class MainWindow:
             elif response == hig.SaveConfirmationAlert.NOSAVE:
                 break
 
-        while not renderqueue.instance.empty():
+        while not self.renderQueue.empty():
             d = hig.ConfirmationAlert(
                 primary=_("Render queue still processing."),
                 secondary=_("If you proceed, queued images will not be saved"),

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -103,16 +103,24 @@ class MainWindow:
             
         self.create_ui()
         self.create_toolbar()
-        self.create_fractal(self.f)
+        self.panes = Gtk.Paned.new(Gtk.Orientation.HORIZONTAL)
+        self.vbox.add(self.panes)
         self.create_status_bar()
+
+        self.create_fractal(self.f)
+        self.panes.pack1(self.swindow, resize=True, shrink=True)
+
+        # show everything apart from the settings pane
+        self.window.show_all()
+
+        self.settingsPane = settings.SettingsPane(self, self.f)
+        self.panes.pack2(self.settingsPane, resize=False, shrink=False)
 
         # create these properly later to avoid 'end from FAM server connection' messages
         self.saveas_fs = None
         self.saveimage_fs = None
         self.hires_image_fs = None
         self.open_fs = None        
-        
-        self.window.show_all()
 
         self.update_subfract_visibility(False)
         self.populate_warpmenu(self.f)
@@ -383,12 +391,6 @@ class MainWindow:
         f.connect('progress_changed', self.progress_changed)
         f.connect('status_changed',self.status_changed)
         f.connect('stats-changed', self.stats_changed)
-
-        hbox = Gtk.HBox()
-        hbox.pack_start(self.swindow, True, True, 0)
-        self.control_box = Gtk.VBox()
-        hbox.pack_start(self.control_box, False, False, 0)
-        self.vbox.pack_start(hbox, True, True, 0)
 
     def draw(self):        
         nt = preferences.userPrefs.getint("general","threads") 
@@ -1216,7 +1218,7 @@ class MainWindow:
         
     def settings(self,*args):
         """Show fractal settings controls."""
-        settings.show_settings(self.window, self.control_box, self.f, False)
+        self.settingsPane.show()
         
     def preferences(self,*args):
         """Change current preferences."""

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -99,8 +99,6 @@ class MainWindow:
             'image-preferences-changed',
             self.on_prefs_changed)
 
-        browser.update(self.f.forms[0].funcFile, self.f.forms[0].funcName)
-            
         self.create_ui()
         self.create_toolbar()
         self.panes = Gtk.Paned.new(Gtk.Orientation.HORIZONTAL)
@@ -724,7 +722,9 @@ class MainWindow:
         
     def browser(self,*args):
         """Display formula browser."""
-        browser.show(self.window,self.f)
+        dialog = browser.BrowserDialog(self, self.f)
+        dialog.run()
+        dialog.destroy()
 
     def randomize_colors(self,*args):
         """Create a new random color scheme."""
@@ -1366,7 +1366,6 @@ class MainWindow:
                 fh.close()
             self.update_recent_files(file)
             self.set_filename(file)
-            browser.update(self.f.forms[0].funcFile, self.f.forms[0].funcName)
             return True
         except Exception as err:
             self.show_error_message(_("Error opening %s") % file,err)
@@ -1375,10 +1374,10 @@ class MainWindow:
     def load_formula(self,file):
         try:
             self.compiler.load_formula_file(file)
-            type = browser.guess_type(file)
-            browser.set_type(type)
-            browser.update(file)
-            browser.show(self.window, self.f, type)
+            dialog = browser.BrowserDialog(self, self.f)
+            dialog.load_file(file)
+            dialog.run()
+            dialog.destroy()
 
             return True
         except Exception as err:

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -66,7 +66,8 @@ class MainWindow:
 
         # create fractal compiler and load standard formula and
         # coloring algorithm files
-        self.compiler = fc.instance
+        self.compiler = fc.Compiler()
+        self.compiler.update_from_prefs(fractconfig.instance)
 
         for path in extra_paths:
             self.compiler.add_func_path(path)

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -718,7 +718,9 @@ class MainWindow:
 
     def director(self,*args):
         """Display the Director (animation) window."""
-        director.show(self.window,self.control_box, self.f, True)
+        dialog = director.DirectorDialog(self.window, self.f)
+        dialog.run()
+        dialog.destroy()
         
     def browser(self,*args):
         """Display formula browser."""

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -849,7 +849,7 @@ class MainWindow:
         
         self.add_fourway(
             _("pan"),
-            _("Pan around the image"), 0, True)
+            _("Pan around the image"), 0, False)
         self.add_fourway(
             _("warp"),
             _("Mutate the image by moving along the other 2 axes"), 2, True)

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -137,6 +137,8 @@ class MainWindow:
 
         self.f.set_saved(True)
 
+        self.painterDialog = painter.PainterDialog(self.window, self.f)
+
     def create_rtd_widgets(self):
         table = Gtk.Table(n_rows=2,n_columns=3,homogeneous=False)
         table.width = width = Gtk.Entry()
@@ -726,7 +728,7 @@ class MainWindow:
         self.f.make_random_colors(8)
 
     def painter(self,*args):
-        painter.show(self.window,self.f)
+        self.painterDialog.show()
 
     def add_to_queue(self,name,w,h):
         renderqueue.show(self.window,None,self.f)

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -1222,7 +1222,9 @@ class MainWindow:
         
     def preferences(self,*args):
         """Change current preferences."""
-        preferences.show_preferences(self.window, self.f)
+        dialog = preferences.PrefsDialog(self.window, self.f)
+        dialog.run()
+        dialog.destroy()
         
     def undo(self,*args):
         """Undo the last operation."""
@@ -1272,7 +1274,9 @@ class MainWindow:
 
     def autozoom(self,*args):
         """Display AutoZoom dialog."""
-        autozoom.show_autozoom(self.window, self.f)
+        dialog = autozoom.AutozoomDialog(self.window, self.f)
+        dialog.run()
+        dialog.destroy()
 
     def contents(self,*args):
         """Show help file contents page."""

--- a/fract4dgui/painter.py
+++ b/fract4dgui/painter.py
@@ -3,8 +3,6 @@
 from gi.repository import Gtk
 
 from . import dialog
-from . import browser
-from . import utils
 
 class PainterDialog(dialog.T):
     def __init__(self,main_window,f):
@@ -17,7 +15,7 @@ class PainterDialog(dialog.T):
         )
 
         self.f = f
-        self.paint_toggle = Gtk.ToggleButton(_("Painting"))
+        self.paint_toggle = Gtk.ToggleButton.new_with_label(_("Painting"))
         self.paint_toggle.set_active(True)
         self.paint_toggle.connect('toggled',self.onChangePaintMode)
         self.csel = Gtk.ColorSelection()
@@ -34,4 +32,4 @@ class PainterDialog(dialog.T):
                id == Gtk.ResponseType.NONE or \
                id == Gtk.ResponseType.DELETE_EVENT:
             self.hide()
-            self.f.set_paint_mode(False,None) 
+            self.f.set_paint_mode(False,None)

--- a/fract4dgui/painter.py
+++ b/fract4dgui/painter.py
@@ -6,24 +6,16 @@ from . import dialog
 from . import browser
 from . import utils
 
-def show(parent,f):
-    PainterDialog.show(parent,f)
-
 class PainterDialog(dialog.T):
-    def show(parent, f):
-        dialog.T.reveal(PainterDialog, True, parent, None, f)
-
-    show = staticmethod(show)
-    
     def __init__(self,main_window,f):
         dialog.T.__init__(
             self,
             _("Painter"),
             main_window,
             (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True)
+            modal=False
+        )
 
-        self.main_window = main_window
         self.f = f
         self.paint_toggle = Gtk.ToggleButton(_("Painting"))
         self.paint_toggle.set_active(True)

--- a/fract4dgui/preferences.py
+++ b/fract4dgui/preferences.py
@@ -67,10 +67,8 @@ class Preferences(GObject.GObject):
 GObject.type_register(Preferences)
 
 userPrefs = Preferences(fractconfig.instance)
-    
-def show_preferences(parent,f):
-    PrefsDialog.show(parent,f)
-    
+
+
 class PrefsDialog(dialog.T):
     def __init__(self,main_window,f):
         global userPrefs
@@ -78,8 +76,8 @@ class PrefsDialog(dialog.T):
             self,
             _("Gnofract 4D Preferences"),
             main_window,
-            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True)
+            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
+        )
 
         self.dirchooser = utils.get_directory_chooser(
             _("Select a Formula Directory"),
@@ -94,13 +92,9 @@ class PrefsDialog(dialog.T):
         self.create_compiler_options_page()
         self.create_general_page()
         self.create_helper_options_page()
+        self.vbox.show_all()
         
         self.set_size_request(500,-1)
-
-    def show(parent, f):
-        dialog.T.reveal(PrefsDialog, True, parent, None, f)
-
-    show = staticmethod(show)
 
     def show_error(self,message):
         d = Gtk.MessageDialog(self, Gtk.DialogFlags.MODAL,

--- a/fract4dgui/preferences.py
+++ b/fract4dgui/preferences.py
@@ -1,14 +1,8 @@
 # GUI for user settings
 
-import os
-import sys
+from gi.repository import Gtk, GObject
 
-from gi.repository import Gtk
-from gi.repository import GObject
-
-from . import dialog
-from . import utils
-
+from . import dialog, utils
 from fract4d import fractconfig
 
 class Preferences(GObject.GObject):
@@ -119,7 +113,7 @@ class PrefsDialog(dialog.T):
                 except ValueError:
                     Gtk.idle_add(
                         self.show_error,
-                        "Invalid value for width: '%s'. Must be an integer" % \
+                        "Invalid value for width: '%s'. Must be an integer" %
                         entry.get_text())
                     return False
 
@@ -151,7 +145,7 @@ class PrefsDialog(dialog.T):
                 except ValueError:
                     utils.idle_add(
                         self.show_error,
-                        "Invalid value for height: '%s'. Must be an integer" % \
+                        "Invalid value for height: '%s'. Must be an integer" %
                         entry.get_text())
                     return False
 
@@ -229,11 +223,11 @@ class PrefsDialog(dialog.T):
         self.path_list = Gtk.ListStore(
             GObject.TYPE_STRING)
         
-        path_treeview = Gtk.TreeView (model=self.path_list)
+        path_treeview = Gtk.TreeView(model=self.path_list)
 
-        renderer = Gtk.CellRendererText ()
-        column = Gtk.TreeViewColumn (_('_Directory'), renderer, text=0)
-        path_treeview.append_column (column)
+        renderer = Gtk.CellRendererText()
+        column = Gtk.TreeViewColumn(_('_Directory'), renderer, text=0)
+        path_treeview.append_column(column)
         path_treeview.set_headers_visible(False)
         
         paths = self.prefs.get_list(section_name)
@@ -241,7 +235,7 @@ class PrefsDialog(dialog.T):
             iter = self.path_list.append()
             self.path_list.set(iter,0,path)
 
-        return path_treeview 
+        return path_treeview
 
     def update_prefs(self,name, model):
         list = []
@@ -259,7 +253,7 @@ class PrefsDialog(dialog.T):
         if result == Gtk.ResponseType.OK:
             path = self.dirchooser.get_filename()
 
-            model = pathlist.get_model() 
+            model = pathlist.get_model()
             iter = model.append()
             
             model.set(iter,0,path)
@@ -299,10 +293,10 @@ class PrefsDialog(dialog.T):
         table.attach(flags_label,0,1,1,2,0,0,2,2)
         flags_label.set_mnemonic_widget(entry)
 
-        sw = Gtk.ScrolledWindow ()
-        sw.set_shadow_type (Gtk.ShadowType.ETCHED_IN)
-        sw.set_policy (Gtk.PolicyType.NEVER,
-                       Gtk.PolicyType.AUTOMATIC)
+        sw = Gtk.ScrolledWindow()
+        sw.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        sw.set_policy(Gtk.PolicyType.NEVER,
+                      Gtk.PolicyType.AUTOMATIC)
 
         form_path_section = "formula_path"
 
@@ -325,8 +319,7 @@ class PrefsDialog(dialog.T):
         remove_button = Gtk.Button.new_from_stock(Gtk.STOCK_REMOVE)
         remove_button.connect('clicked', self.remove_dir, form_path_section, pathlist)
         table.attach(remove_button,0,1,4,5,Gtk.AttachOptions.EXPAND | Gtk.AttachOptions.FILL, 0, 2, 2)
-        
-        
+
     def create_helper_options_page(self):
         table = Gtk.Table(n_rows=5,n_columns=2,homogeneous=False)
         label = Gtk.Label(label=_("_Helpers"))
@@ -454,4 +447,3 @@ class PrefsDialog(dialog.T):
         aalabel.set_use_underline(True)
         aalabel.set_mnemonic_widget(optMenu)
         table.attach(aalabel,0,1,5,6,0,0,2,2)
-        

--- a/fract4dgui/renderqueue.py
+++ b/fract4dgui/renderqueue.py
@@ -4,12 +4,9 @@
 
 import copy
 
-from gi.repository import GObject
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject
 
-from . import gtkfractal
-from . import dialog
-from . import preferences
+from . import dialog, gtkfractal, preferences
 
 class QueueEntry:
     def __init__(self, f, name, w, h):
@@ -43,7 +40,7 @@ class T(GObject.GObject):
         self.emit('changed')
         
     def start(self):
-        if self.current == None:
+        if self.current is None:
             next(self)
 
     def empty(self):
@@ -99,9 +96,9 @@ class QueueDialog(dialog.T):
         
         self.controls = Gtk.VBox()
         self.store = Gtk.ListStore(
-            GObject.TYPE_STRING, # name
-            GObject.TYPE_STRING, # size
-            GObject.TYPE_FLOAT, # % complete
+            str, # name
+            str, # size
+            float # % complete
             )
 
         self.view = Gtk.TreeView.new_with_model(self.store)
@@ -128,4 +125,3 @@ class QueueDialog(dialog.T):
         iter = self.store.get_iter_first()
         if iter:
             self.store.set_value(iter,2,progress)
-    

--- a/fract4dgui/renderqueue.py
+++ b/fract4dgui/renderqueue.py
@@ -78,34 +78,21 @@ class T(GObject.GObject):
 # explain our existence to GTK's object system
 GObject.type_register(T)
 
-def show(parent, alt_parent, f):
-    QueueDialog.show(parent, alt_parent, f)
-
-instance = T()
-
 class CellRendererProgress(Gtk.CellRendererProgress):
     def __init__(self):
         Gtk.CellRendererProgress.__init__(self)
         self.set_property("text", "Progress")
 
 class QueueDialog(dialog.T):
-    def show(parent, alt_parent, f):
-        dialog.T.reveal(QueueDialog,True, parent, alt_parent, f)
-            
-    show = staticmethod(show)
-
-    def __init__(self, main_window, f):
+    def __init__(self, main_window, f, renderQueue):
         dialog.T.__init__(
             self,
             _("Render Queue"),
             main_window,
-            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True
+            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
         )
 
-        self.main_window = main_window
-
-        self.q = instance
+        self.q = renderQueue
 
         self.q.connect('changed', self.onQueueChanged)
         self.q.connect('progress-changed', self.onProgressChanged)
@@ -130,6 +117,7 @@ class QueueDialog(dialog.T):
         
         self.controls.add(self.view)
         self.vbox.add(self.controls)
+        self.vbox.show_all()
 
     def onQueueChanged(self,q):
         self.store.clear()

--- a/fract4dgui/settings.py
+++ b/fract4dgui/settings.py
@@ -14,30 +14,20 @@ from .table import Table
 from fract4d import browser_model
 from fract4d.fc import FormulaTypes
 
-def show_settings(parent,alt_parent, f,dialog_mode):
-    SettingsDialog.show(parent,alt_parent, f,dialog_mode)
-
-class SettingsDialog(dialog.T):
-    def show(parent, alt_parent, f,dialog_mode):
-        dialog.T.reveal(SettingsDialog,dialog_mode, parent, alt_parent, f)
-            
-    show = staticmethod(show)
-    
+class SettingsPane(Gtk.Box):
     def __init__(self, main_window, f):
-        dialog.T.__init__(
-            self,
-            _("Fractal Settings"),
-            main_window,
-            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True)
+        Gtk.Box.__init__(self)
+        self.set_orientation(Gtk.Orientation.VERTICAL)
 
         self.main_window = main_window
         self.f = f
+        
+        label_box = dialog.make_label_box(self, _("Fractal Settings"))
         self.notebook = Gtk.Notebook()
         self.notebook.set_name("settings_notebook")
-        self.controls = Gtk.VBox()
-        self.controls.pack_start(self.notebook, True, True, 0)
-        self.vbox.pack_start(self.controls, True, True, 0)
+        self.pack_start(label_box, False, False, 0)
+        self.pack_start(self.notebook, True, True, 0)
+        
         self.tables = [None,None,None,None]
         self.selected_transform = None
         
@@ -48,6 +38,8 @@ class SettingsDialog(dialog.T):
         self.create_general_page()
         self.create_location_page()
         self.create_colors_page()
+
+        self.notebook.show_all()
 
     def gradarea_mousedown(self, widget, event):
         pass
@@ -549,7 +541,7 @@ class SettingsDialog(dialog.T):
         d = hig.ErrorAlert(
             primary=message,
             secondary=secondary_message,
-            parent=self.main_window)
+            parent=self.main_window.window)
         d.run()
         d.destroy()
 

--- a/fract4dgui/settings.py
+++ b/fract4dgui/settings.py
@@ -688,7 +688,9 @@ class SettingsPane(Gtk.Box):
                 self.update_all_widgets(fractal,widget) # recurse
 
     def show_browser(self,button,type):
-        browser.show(self.main_window, self.f, type)
+        dialog = browser.BrowserDialog(self.main_window, self.f, type)
+        dialog.run()
+        dialog.destroy()
         
     def create_param_entry(self,table, row, text, param):
         label = Gtk.Label(label=text)

--- a/fract4dgui/test_browser.py
+++ b/fract4dgui/test_browser.py
@@ -20,14 +20,17 @@ if sys.path[1] != "..": sys.path.insert(1, "..")
 from fract4d import fc, fractal, browser_model
 from fract4dgui import browser
 
+class MockMainWindow:
+    def __init__(self):
+        self.window = None
+        self.compiler = fc.Compiler()
+        self.compiler.add_func_path("../formulas")
+        self.compiler.add_func_path("../fract4d")
 
 class Test(unittest.TestCase):
     def setUp(self):
-        self.compiler = fc.instance
-        self.compiler.add_func_path("../formulas")
-        self.compiler.add_func_path("../fract4d")
-        
-        self.f = fractal.T(self.compiler,self)
+        self.mainWindow = MockMainWindow()
+        self.f = fractal.T(self.mainWindow.compiler,self)
     
     def tearDown(self):
         browser._model = None
@@ -40,17 +43,17 @@ class Test(unittest.TestCase):
             Gtk.main_quit()
 
     def testCreate(self):        
-        b = browser.BrowserDialog(None,self.f)
+        b = browser.BrowserDialog(self.mainWindow, self.f)
         self.assertNotEqual(b,None)
 
-    def testLoadFormula(self):
-        b = browser.BrowserDialog(None,self.f)
+    def testSetFormula(self):
+        b = browser.BrowserDialog(self.mainWindow, self.f)
         b.set_file('gf4d.frm')
         b.set_formula('Newton')
         self.assertEqual(b.ir.errors,[])
 
     def testBadFormula(self):
-        b = browser.BrowserDialog(None,self.f)
+        b = browser.BrowserDialog(self.mainWindow, self.f)
         #print b.model.compiler.path_lists[0]
         b.set_file('test.frm')
         b.set_formula('parse_error')
@@ -63,13 +66,20 @@ class Test(unittest.TestCase):
         self.assertNotEqual(all_text,"")
         self.assertEqual(all_text[0:7],"Errors:")
 
-    def test_update(self):
-        b = browser.BrowserDialog(None,self.f)
-        b = browser.update(None)
-        m = browser_model.instance
-        self.assertEqual(None, m.current.fname)
-        self.assertEqual(None, m.current.formula)
+    def test_init(self):
+        b = browser.BrowserDialog(self.mainWindow, self.f)
+        m = b.model
+        self.assertEqual('gf4d.frm', m.current.fname)
+        self.assertEqual('Mandelbrot', m.current.formula)
 
+    def testLoadFormula(self):
+        b = browser.BrowserDialog(self.mainWindow, self.f)
+        m = b.model
+        # load good formula file
+        b.load_file("../formulas/fractint.cfrm")
+        self.assertEqual('fractint.cfrm', m.current.fname, "failed to load formula")
+        #load missing file
+        self.assertRaises(OSError, b.load_file, "/no_such_dir/wibble.frm")
 
 def suite():
     return unittest.makeSuite(Test,'test')

--- a/fract4dgui/test_director.py
+++ b/fract4dgui/test_director.py
@@ -47,7 +47,7 @@ class Test(unittest.TestCase):
 
         f = fractal.T(g_comp)
         dd=director.DirectorDialog(None,f,"")
-        dd.show(None,None,f,True,"")
+        dd.show()
         dd.animation.set_png_dir("./")
         dd.animation.set_fct_enabled(False)
         dd.animation.add_keyframe("../testdata/director1.fct",1,10,animation.INT_LOG)

--- a/fract4dgui/test_fourway.py
+++ b/fract4dgui/test_fourway.py
@@ -38,7 +38,7 @@ class Test(unittest.TestCase):
     def testAddToWindow(self):
         w = Gtk.Window()
         f = fourway.T("wibble")
-        w.add(f.widget)
+        w.add(f)
         w.show()
         Gtk.main_iteration()
 

--- a/fract4dgui/test_main_window.py
+++ b/fract4dgui/test_main_window.py
@@ -9,10 +9,14 @@ import os
 import sys
 import random
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
+
 import gettext
 os.environ.setdefault('LANG', 'en')
 gettext.install('gnofract4d')
+
 if sys.path[1] != "..": sys.path.insert(1, "..")
 
 from fract4d import fractal

--- a/fract4dgui/test_main_window.py
+++ b/fract4dgui/test_main_window.py
@@ -129,7 +129,6 @@ class Test(unittest.TestCase):
         self.assertEqual(fct1, fct2)
         
     def testDialogs(self):
-        self.mw.director(None,None)
         self.mw.settings(None,None)
         self.mw.contents(None,None)
         self.mw.painter(None,None)

--- a/fract4dgui/test_main_window.py
+++ b/fract4dgui/test_main_window.py
@@ -116,17 +116,6 @@ class Test(unittest.TestCase):
         finally:
             if os.path.exists("mygood.png"):
                 os.remove("mygood.png")
-            
-    def testLoadFormula(self):
-        # load good formula file
-        result = self.mw.load_formula("../formulas/fractint.cfrm")
-        self.assertEqual(result, True, "failed to load formula")
-
-        #load missing file
-        result = self.mw.load_formula("/no_such_dir/wibble.frm")
-        self.assertEqual(result, False, "load bad formula succeeded")
-        self.assertEqual(
-            self.mw.errors[0][0], "Error opening /no_such_dir/wibble.frm")
 
     def testPreview(self):
         'Check for problem where preview differs from main image'
@@ -143,7 +132,6 @@ class Test(unittest.TestCase):
         self.mw.director(None,None)
         self.mw.settings(None,None)
         self.mw.contents(None,None)
-        self.mw.browser(None,None)
         self.mw.painter(None,None)
         
     def testFileDialogs(self):

--- a/fract4dgui/test_main_window.py
+++ b/fract4dgui/test_main_window.py
@@ -142,8 +142,6 @@ class Test(unittest.TestCase):
     def testDialogs(self):
         self.mw.director(None,None)
         self.mw.settings(None,None)
-        self.mw.preferences(None,None)
-        self.mw.autozoom(None,None)
         self.mw.contents(None,None)
         self.mw.browser(None,None)
         self.mw.painter(None,None)

--- a/fract4dgui/test_painter.py
+++ b/fract4dgui/test_painter.py
@@ -8,10 +8,14 @@ import math
 import os
 import sys
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
+
 import gettext
 os.environ.setdefault('LANG', 'en')
 gettext.install('gnofract4d')
+
 if sys.path[1] != "..": sys.path.insert(1, "..")
 
 from fract4d import fc, fractal

--- a/fract4dgui/test_preferences.py
+++ b/fract4dgui/test_preferences.py
@@ -6,6 +6,9 @@ import unittest
 import sys
 import os
 
+import gi
+gi.require_version('Gtk', '3.0')
+
 if sys.path[1] != "..": sys.path.insert(1, "..")
 from fract4dgui import preferences
 from fract4d import fractconfig

--- a/fract4dgui/test_renderqueue.py
+++ b/fract4dgui/test_renderqueue.py
@@ -66,13 +66,14 @@ class Test(unittest.TestCase):
 
     def testQueueDialog(self):
         f = fractal.T(g_comp)
-        renderqueue.show(None,None,f)
-        rq = renderqueue.instance
+        rq = renderqueue.T()
         rq.add(f,"foo.png",124,276)
         rq.add(f,"foo2.png",204,153)
         rq.add(f,"foo3.png",80,40)
         rq.connect('done', self.quitloop)
         rq.start()
+        d = renderqueue.QueueDialog(None, f, rq)
+        d.show()
         self.wait()
         os.remove("foo.png"); os.remove("foo2.png"); os.remove("foo3.png")
 

--- a/fract4dgui/test_settings.py
+++ b/fract4dgui/test_settings.py
@@ -29,7 +29,7 @@ class Test(unittest.TestCase):
         self.compiler.add_func_path("../fract4d")
         
         self.f = gtkfractal.T(self.compiler)
-        self.settings = settings.SettingsDialog(None,self.f)
+        self.settings = settings.SettingsPane(None,self.f)
         
     def tearDown(self):
         pass


### PR DESCRIPTION
I'd seen various bits of odd behaviour, first with the fourway's leading to a89e39cb8a8990e12ef674f6ed3d24363ece0ef0.
Also GTK+ Critical errors on the command line and Python exceptions. 

And something strange in the code:
https://github.com/edyoung/gnofract4d/blob/572dbeecde9cef266167a479368675c710e77926/fract4dgui/browser.py#L162-L163

I can't find any other examples of testing the existence of GtkTreeSelection, indeed the GTK+ docs say:
"The GtkTreeSelection object is automatically created when a new GtkTreeView widget is created, and cannot exist independently of this widget."

I think this is all the result of a confusion of classes, objects, static methods and scope. This set attempts to fix that.

There are a couple of improvements too:
- The formula browser now opens with the current file and formula selected
- The fractal settings can now be dragged wider by the user (but not shrunk).

Hope that makes sense. There a few comments in the commit messages.
