### PR TITLE
Fix Video Creation

### DIFF
--- a/doc/gnofract4d-manual/C/gnofract4d-manual.xml
+++ b/doc/gnofract4d-manual/C/gnofract4d-manual.xml
@@ -354,7 +354,7 @@ Tips:
 
 <listitem><para>
 In order to end up with a video file, not just a bunch of images, you need to have
-<emphasis>ffmpeg</emphasis> compiled with support for zlib.
+<emphasis>ffmpeg</emphasis> compiled with support for zlib and libvpx.
 </para></listitem>
 
 <listitem><para>

--- a/doc/gnofract4d-manual/C/gnofract4d-manual.xml
+++ b/doc/gnofract4d-manual/C/gnofract4d-manual.xml
@@ -345,17 +345,16 @@ keyframe will stay in video (<guilabel>stopped for</guilabel>) and
 interpolation type between several possibilities. When you hit
 <guibutton>Render</guibutton> button, Director will render all frames
 and put them in directory you selected and then it will try to create
-video using <ulink
-url="http://www.transcoding.org/"><emphasis>transcode</emphasis></ulink>
-tool.  </para>
+a video using <ulink url="https://www.ffmpeg.org/">
+<emphasis>FFmpeg</emphasis></ulink>.</para>
 
 <para>
 Tips:
 <itemizedlist>
 
 <listitem><para>
-In order to end up with video file, not just a bunch of images, you need to have
-<emphasis>transcode</emphasis> tool compiled with support for ImageMagick.
+In order to end up with a video file, not just a bunch of images, you need to have
+<emphasis>ffmpeg</emphasis> compiled with support for zlib.
 </para></listitem>
 
 <listitem><para>

--- a/fract4d/animation.py
+++ b/fract4d/animation.py
@@ -67,7 +67,7 @@ class T:
         self.width = 640
         self.height = 480
         self.framerate = 25
-        self.redblue = True
+        self.redblue = False
         # keyframes is a list of KeyFrame objects
         self.keyframes = []
 

--- a/fract4d/animation.py
+++ b/fract4d/animation.py
@@ -1,48 +1,48 @@
 #!/usr/bin/python
 
-import os, sys, copy, math
+import os
+import math
 
 from xml.sax import make_parser
 from xml.sax.handler import ContentHandler
 
-from . import fracttypes
-from . import fractal
 from . import fractconfig
 
-#interpolation type constants
-INT_LINEAR=    0
-INT_LOG=    1
-INT_INVLOG=    2
-INT_COS=    3
+# interpolation type constants
+INT_LINEAR = 0
+INT_LOG    = 1
+INT_INVLOG = 2
+INT_COS    = 3
 
 def getAttrOrDefault(attrs, name, default):
     x = attrs.get(name)
-    if x == None:
+    if x is None:
         x = default
     return x
     
 def getAttrOrElse(attrs, name):
     x = attrs.get(name)
-    if x == None:
+    if x is None:
         raise ValueError(
             "Invalid file: Cannot find required attribute '%s'" % name)
     return x
 
 class KeyFrame:
-    def __init__(self,filename,duration,stop,int_type,flags=(0,0,0,0,0,0)):
+    def __init__(self, filename, duration, stop, int_type, flags=(0,0,0,0,0,0)):
         self.filename = filename
         self.duration = duration
         self.stop = stop
         self.int_type = int_type
         self.flags = flags
 
-    def save(self,fh):
+    def save(self, fh):
         fh.write(
             '\t\t<keyframe filename="%s" duration="%d" stop="%d" inttype="%d" ' % (self.filename, self.duration, self.stop, self.int_type))
         fh.write(
             'xy="%d" xz="%d" xw="%d" yz="%d" yw="%d" zw="%d"' % self.flags)
         fh.write('/>\n')
 
+    @staticmethod
     def load_from_xml(attrs):
         kf = KeyFrame(
             getAttrOrElse(attrs,"filename"),
@@ -56,8 +56,6 @@ class KeyFrame:
              int(getAttrOrDefault(attrs,"yw",0)),
              int(getAttrOrDefault(attrs,"zw",0))))
         return kf
-    
-    load_from_xml=staticmethod(load_from_xml)
         
 class T:
     def __init__(self, compiler):
@@ -65,13 +63,13 @@ class T:
         self.reset()
 
     def reset(self):
-        self.avi_file=""
-        self.width=640
-        self.height=480
-        self.framerate=25
-        self.redblue=True
-        #keyframes is a list of KeyFrame objects
-        self.keyframes=[]
+        self.avi_file = ""
+        self.width = 640
+        self.height = 480
+        self.framerate = 25
+        self.redblue = True
+        # keyframes is a list of KeyFrame objects
+        self.keyframes = []
 
     def get_fct_enabled(self):
         return fractconfig.instance.getboolean("director","fct_enabled")
@@ -98,63 +96,63 @@ class T:
         return self.avi_file
 
     def set_avi_file(self,file):
-        if file!=None:
-            self.avi_file=file
+        if file is not None:
+            self.avi_file = file
         else:
-            self.avi_file=""
+            self.avi_file = ""
 
     def get_width(self):
         return self.width
 
     def set_width(self,width):
-        if width!=None:
-            self.width=int(width)
+        if width is not None:
+            self.width = int(width)
         else:
-            self.width=640
+            self.width = 640
 
     def get_height(self):
         return self.height
 
     def set_height(self,height):
-        if height!=None:
-            self.height=int(height)
+        if height is not None:
+            self.height = int(height)
         else:
-            self.height=480
+            self.height = 480
 
     def get_framerate(self):
         return self.framerate
 
     def set_framerate(self,fr):
-        if fr!=None:
-            self.framerate=int(fr)
+        if fr is not None:
+            self.framerate = int(fr)
         else:
-            self.framerate=25
+            self.framerate = 25
 
     def get_redblue(self):
         return self.redblue
 
     def set_redblue(self,rb):
-        if rb!=None:
-            if rb==1:
-                self.redblue=True
-            elif rb==0:
-                self.redblue=False
-                self.redblue=rb
+        if rb is not None:
+            if rb == 1:
+                self.redblue = True
+            elif rb == 0:
+                self.redblue = False
+                self.redblue = rb
         else:
-            self.redblue=True
+            self.redblue = True
 
     def add_keyframe(self,filename,duration,stop,int_type,index=None):
         kf = KeyFrame(filename,duration,stop,int_type)
-        if index==None:
+        if index is None:
             self.keyframes.append(kf)
         else:
             self.keyframes.insert(index, kf)
 
     def remove_keyframe(self,index):
-        self.keyframes[index:index+1]=[]
+        del self.keyframes[index:index+1]
 
     def change_keyframe(self,index,duration,stop,int_type):
-        if index<len(self.keyframes):
+        if index < len(self.keyframes):
             kf = self.keyframes[index]
             kf.duration = duration
             kf.stop = stop
@@ -170,91 +168,90 @@ class T:
         return self.keyframes[index].duration
 
     def set_keyframe_duration(self,index,duration):
-        if index<len(self.keyframes):
+        if index < len(self.keyframes):
             self.keyframes[index].duration = duration
 
     def get_keyframe_stop(self,index):
         return self.keyframes[index].stop
 
     def set_keyframe_stop(self,index,stop):
-        if index<len(self.keyframes):
-            self.keyframes[index].stop= stop
+        if index < len(self.keyframes):
+            self.keyframes[index].stop = stop
 
     def get_keyframe_int(self,index):
         return self.keyframes[index].int_type
 
     def set_keyframe_int(self,index,int_type):
-        if index<len(self.keyframes):
-            self.keyframes[index].int_type=int_type
+        if index < len(self.keyframes):
+            self.keyframes[index].int_type = int_type
 
     def get_directions(self,index):
         return self.keyframes[index].flags
 
     def set_directions(self,index,drct):
-        if index<len(self.keyframes):
+        if index < len(self.keyframes):
             self.keyframes[index].flags = drct
 
     def keyframes_count(self):
         return len(self.keyframes)
 
     def __getstate__(self):
-        odict = self.__dict__.copy() # copy the dict since we change it
+        odict = self.__dict__.copy()  # copy the dict since we change it
         #del odict['fh']              # remove filehandle entry
         return odict
 
     def __setstate__(self,dict):
-        self.keyframes=[]
+        self.keyframes = []
         self.__dict__.update(dict)   # update attributes
 
     def load_animation(self,file):
-        #save __dict__ if there was error
+        # save __dict__ if there was error
         odict = self.__dict__.copy()
         import traceback
         try:
-            self.keyframes=[]
+            self.keyframes = []
             parser = make_parser()
             ah = AnimationHandler(self)
             parser.setContentHandler(ah)
             parser.parse(open(file))
         except Exception as err:
-            #retrieve previous__dict__
-            self.__dict__=odict
+            # retrieve previous__dict__
+            self.__dict__ = odict
             raise
 
     def save_animation(self,file):
-        fh=open(file,"w")
-        fh.write('<?xml version="1.0"?>\n')
-        fh.write("<animation>\n")
-        fh.write('\t<keyframes>\n')
-        for kf in self.keyframes:
-            kf.save(fh)
-        fh.write('\t</keyframes>\n')
-        fh.write('\t<output filename="%s" framerate="%d" width="%d" height="%d" swap="%d"/>\n'%
-             (self.avi_file,self.framerate,self.width,self.height,self.redblue))
-        fh.write("</animation>\n")
-        fh.close()
+        with open(file, "w") as fh:
+            fh.write('<?xml version="1.0"?>\n')
+            fh.write("<animation>\n")
+            fh.write('\t<keyframes>\n')
+            for kf in self.keyframes:
+                kf.save(fh)
+            fh.write('\t</keyframes>\n')
+            fh.write('\t<output filename="%s" framerate="%d" width="%d" height="%d" swap="%d"/>\n' %
+                 (self.avi_file,self.framerate,self.width,self.height,self.redblue))
+            fh.write("</animation>\n")
 
-    #leftover from debugging purposes
+    # leftover from debugging purposes
     def pr(self):
         print(self.__dict__)
 
     def get_image_filename(self,n):
         "The filename of the image containing the Nth frame"
-        return os.path.join(self.get_png_dir(),"image_%07d.png" %n)
+        return os.path.join(self.get_png_dir(), "image_%07d.png" % n)
 
     def get_fractal_filename(self,n):
         "The filename of the .fct file which generates the Nth frame"
         return os.path.join(self.get_fct_dir(),"file_%07d.fct" % n)
 
     def get_mu(self, int_type, x):
-        if int_type==INT_LINEAR:
-            mu=x
-        elif int_type==INT_LOG:
-            mu=math.log(x+1,2)
-        elif int_type==INT_INVLOG:
-            mu=(math.exp(x)-1)/(math.e-1)
-        elif int_type==INT_COS:
-            mu=(1-math.cos(x*math.pi))/2
+        if int_type == INT_LINEAR:
+            mu = x
+        elif int_type == INT_LOG:
+            mu = math.log(x+1,2)
+        elif int_type == INT_INVLOG:
+            mu = (math.exp(x)-1) / (math.e-1)
+        elif int_type == INT_COS:
+            mu = (1-math.cos(x*math.pi)) / 2
         else:
             raise ValueError("Unknown interpolation type %d" % int_type)
         return mu
@@ -262,18 +259,16 @@ class T:
     # create a list containing all the filenames of the frames
     def create_list(self):
         framelist = []
-        folder_png=self.get_png_dir()
-
-        current=1
+        current = 1
         for i in range(self.keyframes_count()):
-            for j in range(self.get_keyframe_stop(i)): #output keyframe 'stop' times
+            for j in range(self.get_keyframe_stop(i)):  # output keyframe 'stop' times
                 framelist.append(self.get_image_filename(current-1))
 
             if i < self.keyframes_count()-1:
                 # final frame has no transitions following it
-                for j in range(self.get_keyframe_duration(i)): #output all transition files
+                for j in range(self.get_keyframe_duration(i)):  # output all transition files
                     framelist.append(self.get_image_filename(current))
-                    current=current+1
+                    current += 1
         
         return framelist
 
@@ -296,17 +291,16 @@ class T:
     
 class AnimationHandler(ContentHandler):
     def __init__(self,animation):
-        self.animation=animation
+        self.animation = animation
 
     def startElement(self, name, attrs):
-        if name=="output":
+        if name == "output":
             self.animation.set_avi_file(attrs.get("filename"))
             self.animation.set_framerate(attrs.get("framerate"))
             self.animation.set_width(attrs.get("width"))
             self.animation.set_height(attrs.get("height"))
             self.animation.set_redblue(int(attrs.get("swap")))
-        elif name=="keyframe":
-            kf= KeyFrame.load_from_xml(attrs)
+        elif name == "keyframe":
+            kf = KeyFrame.load_from_xml(attrs)
             self.animation.keyframes.append(kf)
         return
-

--- a/fract4d/browser_model.py
+++ b/fract4d/browser_model.py
@@ -99,12 +99,12 @@ class T:
             TypeInfo(self, compiler, fc.FormulaTypes.TRANSFORM),
             TypeInfo(self, compiler, fc.FormulaTypes.GRADIENT)
             ]
+        self.current = None
         self.current_type = -1
         self.type_changed = event.T()
         self.file_changed = event.T()
         self.formula_changed = event.T()
-        self.set_type(FRACTAL)
-        
+
     def formula_type_to_browser_type(self,t):
         if t == fc.FormulaTypes.FRACTAL:
             return FRACTAL

--- a/fract4d/browser_model.py
+++ b/fract4d/browser_model.py
@@ -157,5 +157,3 @@ class T:
 
         r = self.compiler.get_text(fname)
         return r
-        
-instance = T(fc.instance)

--- a/fract4d/cache.py
+++ b/fract4d/cache.py
@@ -33,7 +33,6 @@ class T:
         self.createPickledFile(self._indexName(), self.files)
     
     def clear(self):
-        if not os: return # get 'NoneType not callable' sometimes otherwise, which seems weird
         for f in os.listdir(self.dir):
             try:
                 os.remove(os.path.join(self.dir,f))

--- a/fract4d/fc.py
+++ b/fract4d/fc.py
@@ -493,9 +493,6 @@ class Compiler:
         if not self.leave_dirty:
             self.clear_cache()
 
-instance = Compiler()
-instance.update_from_prefs(fractconfig.instance)
-
 def usage():
     print("FC : a compiler from Fractint .frm files to C code")
     print("fc.py -o [outfile] -f [formula] infile")

--- a/fract4d/fractconfig.py
+++ b/fract4d/fractconfig.py
@@ -27,8 +27,7 @@ class T(configparser.ConfigParser):
             "helpers" : {
               "editor" : self.get_default_editor(),
               "mailer" : self.get_default_mailer(),
-              "browser" : self.get_default_browser(),
-              "video_encoder" : "transcode"
+              "browser" : self.get_default_browser()
             },
             "general" : {
               "threads" : "1",

--- a/fract4d/test_animation.py
+++ b/fract4d/test_animation.py
@@ -29,7 +29,7 @@ class Test(unittest.TestCase):
         self.assertEqual(self.anim.get_width(),640)
         self.assertEqual(self.anim.get_height(),480)
         self.assertEqual(self.anim.get_framerate(),25)
-        self.assertEqual(self.anim.get_redblue(),True)
+        self.assertEqual(self.anim.get_redblue(),False)
         self.assertEqual(self.anim.keyframes_count(),0)
 
     def testChangeOptions(self):

--- a/fract4d/test_browser_model.py
+++ b/fract4d/test_browser_model.py
@@ -65,7 +65,8 @@ class Test(testbase.TestBase):
 
     def testSetType(self):
         bm = Wrapper()
-        self.assertEqual([], bm.type_changelist)
+        bm.set_type(browser_model.FRACTAL)
+        self.assertEqual([browser_model.FRACTAL], bm.type_changelist)
         self.assertEqual(browser_model.FRACTAL, bm.current_type)
         self.assertEqual(            
             bm.typeinfo[bm.current_type], bm.current)
@@ -73,11 +74,12 @@ class Test(testbase.TestBase):
         bm.set_type(browser_model.INNER)
         self.assertEqual(browser_model.INNER, bm.current_type)
         self.assertEqual(
-            [browser_model.INNER],
+            [browser_model.FRACTAL, browser_model.INNER],
             bm.type_changelist)
 
     def testFileList(self):
         bm = browser_model.T(g_comp)
+        bm.set_type(browser_model.FRACTAL)
         self.assertNotEqual(bm.current.files, [])
         self.assertListSorted(bm.current.files)
         
@@ -91,6 +93,7 @@ class Test(testbase.TestBase):
 
     def testSetTypeUpdatesFnames(self):
         bm = browser_model.T(g_comp)
+        bm.set_type(browser_model.FRACTAL)
 
         bm.current.fname = "fish"
         bm.current.formula = "haddock"
@@ -107,6 +110,7 @@ class Test(testbase.TestBase):
 
     def testSetFile(self):
         bm = Wrapper()
+        bm.set_type(browser_model.FRACTAL)
         bm.set_file("gf4d.frm")
         self.assertEqual("gf4d.frm",bm.current.fname)
         self.assertEqual(
@@ -116,6 +120,7 @@ class Test(testbase.TestBase):
 
     def testSetBadFile(self):
         bm = browser_model.T(g_comp)
+        bm.set_type(browser_model.FRACTAL)
         self.assertRaises(IOError,bm.set_file,"nonexistent.frm")
 
     def assertListSorted(self,l):
@@ -126,6 +131,7 @@ class Test(testbase.TestBase):
         
     def testFormulasSorted(self):
         bm = browser_model.T(g_comp)
+        bm.set_type(browser_model.FRACTAL)
         bm.set_file("gf4d.frm")
         self.assertListSorted(bm.current.formulas)
         
@@ -141,6 +147,7 @@ class Test(testbase.TestBase):
 
     def testSetFormula(self):
         bm = Wrapper()
+        bm.set_type(browser_model.FRACTAL)
         bm.set_file("gf4d.frm")
         bm.set_formula("Mandelbrot")
         self.assertEqual("Mandelbrot",bm.current.formula)
@@ -149,6 +156,7 @@ class Test(testbase.TestBase):
 
     def testSetFileResetsFormula(self):
         bm = Wrapper()
+        bm.set_type(browser_model.FRACTAL)
         bm.set_file("gf4d.frm")
         bm.set_formula("Mandelbrot")
         bm.set_file("fractint-g4.frm")
@@ -158,7 +166,9 @@ class Test(testbase.TestBase):
 
     def testUpdate(self):
         bm = Wrapper()
-        bm.update("gf4d.frm","Mandelbrot")
+        bm.set_type(browser_model.FRACTAL)
+        bm.set_file("gf4d.frm")
+        bm.set_formula("Mandelbrot")
         self.assertEqual("gf4d.frm",bm.current.fname)
         self.assertEqual("Mandelbrot", bm.current.formula)
 
@@ -172,6 +182,7 @@ class Test(testbase.TestBase):
 
     def testApplyStatus(self):
         bm = browser_model.T(g_comp)
+        bm.set_type(browser_model.FRACTAL)
         self.assertEqual(False, bm.current.can_apply)
 
         bm.set_file("gf4d.frm")
@@ -198,9 +209,7 @@ class Test(testbase.TestBase):
         files = bm.current.files
         self.assertEqual(1,files.count("blatte1.ugr"))
 
-    def testInstance(self):
-        x = browser_model.instance
-        
+
 def suite():
     return unittest.makeSuite(Test,'test')
 

--- a/fract4d/test_fc.py
+++ b/fract4d/test_fc.py
@@ -247,7 +247,8 @@ bailout: abs(real(z)) > 2.0 || abs(imag(z)) > 2.0
         self.assertEqual(["wibble"], compiler.path_lists[3])
         
     def testInstance(self):
-        compiler = fc.instance
+        compiler = fc.Compiler()
+        compiler.update_from_prefs(fractconfig.instance)
         self.assertNotEqual(None, compiler)
         self.assertEqual(
             compiler.flags, fractconfig.instance.get("compiler", "options"))

--- a/fract4dgui/AVIGen.py
+++ b/fract4dgui/AVIGen.py
@@ -15,8 +15,9 @@ from threading import *
 from fract4d import animation, fractconfig
 
 class AVIGeneration:
-    def __init__(self,animation):
+    def __init__(self, animation, parent):
         self.dialog=Gtk.Dialog(
+            transient_for=parent,
             title="Generating AVI file...",
             modal=True,
             destroy_with_parent=True)

--- a/fract4dgui/AVIGen.py
+++ b/fract4dgui/AVIGen.py
@@ -1,18 +1,15 @@
-#UI and logic for generation of AVI file from bunch of images
-#it knows from director bean class where images are stored (there is also a list file
-#containing list of images that will be frames - needed for transcode) and it create
-#thread to call transcode.
+# UI and logic for generation of AVI file from bunch of images
+# it knows from director bean class where images are stored (there is also a list file
+# containing list of images that will be frames - needed for transcode) and it create
+# thread to call transcode.
 
-#Limitations: user can destroy dialog, but it will not destroy transcode process!?
+# Limitations: user can destroy dialog, but it will not destroy transcode process!?
 
-
-
-from gi.repository import Gdk, Gtk, GObject, GLib
 import os
 import re
 from threading import *
 
-from fract4d import animation, fractconfig
+from gi.repository import Gdk, Gtk, GLib
 
 class AVIGeneration:
     def __init__(self, animation, parent):
@@ -34,17 +31,17 @@ class AVIGeneration:
         self.delete_them=-1
 
     def generate_avi(self):
-        #-------getting all needed information------------------------------
+        # -------getting all needed information------------------------------
         folder_png=self.animation.get_png_dir()
         list_file = os.path.join(folder_png, "list")
 
         avi_file=self.animation.get_avi_file()
         framerate=self.animation.get_framerate()
         yield True
-        #------------------------------------------------------------------
+        # ------------------------------------------------------------------
 
         try:
-            if self.running==False:
+            if self.running is False:
                 yield False
                 return
 
@@ -52,10 +49,10 @@ class AVIGeneration:
                 Gdk.threads_enter()
                 error_dlg = Gtk.MessageDialog(
                     self.dialog,
-                    Gtk.DialogFlags.MODAL  | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+                    Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
                     Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,
                     "In directory: %s there is no listing file. Cannot continue" %(folder_png))
-                response=error_dlg.run()
+                error_dlg.run()
                 error_dlg.destroy()
                 Gdk.threads_leave()
                 event = Gdk.Event(Gdk.EventType.DELETE)
@@ -63,9 +60,9 @@ class AVIGeneration:
                 yield False
                 return
             
-            #--------calculating total number of frames------------
+            # --------calculating total number of frames------------
             count=self.animation.get_total_frames()
-            #------------------------------------------------------
+            # ------------------------------------------------------
             # calling ffmpeg
             swap=""
             if self.animation.get_redblue():
@@ -78,11 +75,11 @@ class AVIGeneration:
 
             working=True
             while(working):
-                dt.join(0.5) #refresh gtk every 0.5 seconds
+                dt.join(0.5)  # refresh gtk every 0.5 seconds
                 working=dt.isAlive()
                 yield True
 
-            if self.running==False:
+            if self.running is False:
                 yield False
                 return
             yield True
@@ -96,20 +93,19 @@ class AVIGeneration:
             error_dlg.run()
             error_dlg.destroy()
             Gdk.threads_leave()
-            event = Gdk.Event(Gdk.DELETE)
+            event = Gdk.Event(Gdk.EventType.DELETE)
             self.dialog.emit('delete_event', event)
             yield False
             return
-        if self.running==False:
+        if self.running is False:
             yield False
             return
         self.running=False
         self.dialog.destroy()
         yield False
 
-
     def show(self):
-        #------------------------------------------------------------
+        # ------------------------------------------------------------
         self.dialog.show_all()
         self.running=True
         self.error=False
@@ -117,23 +113,23 @@ class AVIGeneration:
         GLib.idle_add(task.__next__)
         response = self.dialog.run()
         if response != Gtk.ResponseType.CANCEL:
-            if self.running==True: #destroy by user
+            if self.running is True:  # destroy by user
                 self.running=False
                 self.dialog.destroy()
                 return 1
             else:
-                if self.error==True: #error
+                if self.error is True:  # error
                     self.dialog.destroy()
                     return -1
-                else: #everything ok
+                else:  # everything ok
                     self.dialog.destroy()
                     return 0
-        else: #cancel pressed
+        else:  # cancel pressed
             self.running=False
             self.dialog.destroy()
             return 1
 
-#thread for calling transcode
+# thread for calling transcode
 class DummyThread(Thread):
     def __init__(self,s,pbar,count):
         Thread.__init__(self)
@@ -147,7 +143,7 @@ class DummyThread(Thread):
         pipe=os.popen(self.s)
         for line in pipe:
             m=reg.search(line)
-            if m!=None:
+            if m is not None:
                 cur=re.split("-",m.group())[1][0:-1]
                 self.pbar.set_fraction(float(cur)/self.count)
         pipe.close()

--- a/fract4dgui/AVIGen.py
+++ b/fract4dgui/AVIGen.py
@@ -1,150 +1,134 @@
-# UI and logic for generation of AVI file from bunch of images
-# it knows from director bean class where images are stored (there is also a list file
-# containing list of images that will be frames - needed for transcode) and it create
-# thread to call transcode.
-
-# Limitations: user can destroy dialog, but it will not destroy transcode process!?
+# UI and logic for generation of a video file from a bunch of images.
+# Uses a list file containing the images that will be frames
+# and creates a subprocess to execute ffmpeg.
 
 import os
-import re
-from threading import *
+import signal
 
 from gi.repository import Gdk, Gtk, GLib
 
 class AVIGeneration:
     def __init__(self, animation, parent):
-        self.dialog=Gtk.Dialog(
-            transient_for=parent,
-            title="Generating AVI file...",
-            modal=True,
-            destroy_with_parent=True)
+        self.animation = animation
+        self.converterpath = parent.converterpath
+        self.fh_err = None
+        self.pid = None
 
+        self.dialog = Gtk.Dialog(
+            transient_for=parent,
+            title="Generating video file",
+            modal=True,
+            destroy_with_parent=True
+        )
         self.dialog.add_buttons(Gtk.STOCK_CANCEL,Gtk.ResponseType.CANCEL)
-        self.pbar = Gtk.ProgressBar()
-        self.pbar.set_text("Please wait...")
-        self.dialog.vbox.pack_start(self.pbar,True,True,0)
+        self.spinner = Gtk.Spinner()
+        label = Gtk.Label.new("Please wait...")
+        self.dialog.vbox.pack_start(self.spinner, True, True, 10)
+        self.dialog.vbox.pack_start(label, True, True, 10)
         geometry = Gdk.Geometry()
         geometry.min_aspect = 3.5
         geometry.max_aspect = 3.5
         self.dialog.set_geometry_hints(None, geometry, Gdk.WindowHints.ASPECT)
-        self.animation=animation
-        self.delete_them=-1
 
     def generate_avi(self):
-        # -------getting all needed information------------------------------
-        folder_png=self.animation.get_png_dir()
+        folder_png = self.animation.get_png_dir()
         list_file = os.path.join(folder_png, "list")
+        video_file = self.animation.get_avi_file()
+        framerate = self.animation.get_framerate()
 
-        avi_file=self.animation.get_avi_file()
-        framerate=self.animation.get_framerate()
-        yield True
-        # ------------------------------------------------------------------
-
-        try:
-            if self.running is False:
-                yield False
-                return
-
-            if not os.path.exists(list_file):
-                Gdk.threads_enter()
-                error_dlg = Gtk.MessageDialog(
-                    self.dialog,
-                    Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
-                    Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,
-                    "In directory: %s there is no listing file. Cannot continue" %(folder_png))
-                error_dlg.run()
-                error_dlg.destroy()
-                Gdk.threads_leave()
-                event = Gdk.Event(Gdk.EventType.DELETE)
-                self.dialog.emit('delete_event', event)
-                yield False
-                return
-            
-            # --------calculating total number of frames------------
-            count=self.animation.get_total_frames()
-            # ------------------------------------------------------
-            # calling ffmpeg
-            swap=""
-            if self.animation.get_redblue():
-                swap='-vf "colorchannelmixer=rr=0:rb=1:br=1:bb=0"'
-
-            call = "ffmpeg -r %d -f concat -safe 0 -i %s %s -r %d %s" % \
-                (framerate, list_file, swap, framerate, avi_file)
-            dt=DummyThread(call,self.pbar,float(count))
-            dt.start()
-
-            working=True
-            while(working):
-                dt.join(0.5)  # refresh gtk every 0.5 seconds
-                working=dt.isAlive()
-                yield True
-
-            if self.running is False:
-                yield False
-                return
-            yield True
-        except Exception as err:
-            self.running=False
-            self.error=True
-            Gdk.threads_enter()
-            error_dlg = Gtk.MessageDialog(self.dialog,Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
-                    Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,
-                    _("Error during generation of avi file: %s" % err))
+        if not os.path.exists(list_file):
+            error_dlg = Gtk.MessageDialog(
+                transient_for=self.dialog,
+                title="Cannot continue",
+                modal=True,
+                destroy_with_parent=True,
+                message_type=Gtk.MessageType.ERROR,
+                buttons=Gtk.ButtonsType.OK,
+                text="In directory: %s there is no listing file" % (folder_png)
+            )
             error_dlg.run()
             error_dlg.destroy()
-            Gdk.threads_leave()
-            event = Gdk.Event(Gdk.EventType.DELETE)
-            self.dialog.emit('delete_event', event)
-            yield False
             return
-        if self.running is False:
-            yield False
-            return
-        self.running=False
-        self.dialog.destroy()
-        yield False
+        
+        self.spinner.start()
+        
+        # calling ffmpeg
+        # https://trac.ffmpeg.org/wiki/Concatenate
+        # https://trac.ffmpeg.org/wiki/Encode/VP9
+        call = [
+            self.converterpath, "-nostdin", "-y",
+            "-loglevel", "error", "-hide_banner",
+            "-r", str(framerate), "-f", "concat", "-safe", "0", "-i", list_file]
+        if self.animation.get_redblue():
+            call.extend(["-vf", "colorchannelmixer=rr=0:rb=1:br=1:bb=0"])
+        call.extend([
+            "-c:v", "libvpx-vp9", "-crf", "30", "-b:v", "0",
+            "-r", str(framerate), video_file])
+        self.pid, fd_in, fd_out, fd_err = GLib.spawn_async(call,
+                                    flags=GLib.SpawnFlags.DO_NOT_REAP_CHILD,
+                                    standard_output=False, standard_error=True)
+        self.fh_err = os.fdopen(fd_err, "r")
+        GLib.child_watch_add(GLib.PRIORITY_DEFAULT, self.pid, self.video_complete)
+        GLib.io_add_watch(self.fh_err, GLib.PRIORITY_DEFAULT, GLib.IOCondition.IN, self.video_error)
+
+    def video_error(self, source, condition):
+        error_text = source.read()
+        print(error_text)
+        error_dlg = Gtk.MessageDialog(
+            transient_for=self.dialog,
+            title=_("Error generating video file"),
+            modal=True,
+            destroy_with_parent=True,
+            message_type=Gtk.MessageType.ERROR,
+            buttons=Gtk.ButtonsType.OK,
+            text=error_text)
+        error_dlg.run()
+        error_dlg.destroy()
+
+    def video_complete(self, pid, status):
+        self.spinner.stop()
+        self.running = False
+        if status == 0:
+            self.error = False
+        else:
+            self.error = True
+        self.dialog.emit('delete_event', Gdk.Event())
 
     def show(self):
-        # ------------------------------------------------------------
         self.dialog.show_all()
-        self.running=True
-        self.error=False
-        task=self.generate_avi()
-        GLib.idle_add(task.__next__)
+        self.running = True
+        self.error = False
+        
+        try:
+            self.generate_avi()
+        except GLib.GError as err:
+            error_dlg = Gtk.MessageDialog(
+                transient_for=self.dialog,
+                title=_("Error executing video converter"),
+                modal=True,
+                destroy_with_parent=True,
+                message_type=Gtk.MessageType.ERROR,
+                buttons=Gtk.ButtonsType.OK,
+                text=str(err))
+            error_dlg.run()
+            error_dlg.destroy()
+            
+            return -1
+        
+        result = 0
         response = self.dialog.run()
-        if response != Gtk.ResponseType.CANCEL:
+        if response == Gtk.ResponseType.CANCEL:
+            # cancel pressed
+            result = 1
+        else:
             if self.running is True:  # destroy by user
-                self.running=False
-                self.dialog.destroy()
-                return 1
-            else:
-                if self.error is True:  # error
-                    self.dialog.destroy()
-                    return -1
-                else:  # everything ok
-                    self.dialog.destroy()
-                    return 0
-        else:  # cancel pressed
-            self.running=False
-            self.dialog.destroy()
-            return 1
+                GLib.spawn_close_pid(self.pid)
+                os.kill(self.pid, signal.SIGTERM)
+                result = 1
+            elif self.error is True:  # error
+                result = -1
 
-# thread for calling transcode
-class DummyThread(Thread):
-    def __init__(self,s,pbar,count):
-        Thread.__init__(self)
-        self.s=s
-        self.pbar=pbar
-        self.count=count
-
-    def run(self):
-        #os.system(self.s) <----this is little faster, but user can't see any progress
-        reg=re.compile("\[.*-.*\]")
-        pipe=os.popen(self.s)
-        for line in pipe:
-            m=reg.search(line)
-            if m is not None:
-                cur=re.split("-",m.group())[1][0:-1]
-                self.pbar.set_fraction(float(cur)/self.count)
-        pipe.close()
-        return
+        if self.fh_err:
+            self.fh_err.close()
+        self.dialog.destroy()
+        return result

--- a/fract4dgui/DlgAdvOpt.py
+++ b/fract4dgui/DlgAdvOpt.py
@@ -14,10 +14,15 @@ from threading import *
 
 class DlgAdvOptions:
 
-    def __init__(self,current_kf,animation):
-        self.dialog=Gtk.Dialog("Keyframe advanced options...",None,
-                    Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
-                    (Gtk.STOCK_OK,Gtk.ResponseType.OK,Gtk.STOCK_CANCEL,Gtk.ResponseType.CANCEL))
+    def __init__(self,current_kf,animation,parent):
+        self.dialog=Gtk.Dialog(
+            transient_for=parent,
+            title="Keyframe advanced options",
+            modal=True,
+            destroy_with_parent=True
+        )
+        self.dialog.add_buttons(Gtk.STOCK_OK, Gtk.ResponseType.OK,
+            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
 
         self.current_kf=current_kf
         self.animation=animation

--- a/fract4dgui/DlgAdvOpt.py
+++ b/fract4dgui/DlgAdvOpt.py
@@ -5,15 +5,11 @@
 #   DlgAdvOpt.py: dialog for advanced interpolation options for director
 #
 
-from gi.repository import Gtk
-from gi.repository import GObject
-import os
-import re
 from threading import *
 
+from gi.repository import Gtk
 
 class DlgAdvOptions:
-
     def __init__(self,current_kf,animation,parent):
         self.dialog=Gtk.Dialog(
             transient_for=parent,

--- a/fract4dgui/FCTGen.py
+++ b/fract4dgui/FCTGen.py
@@ -356,14 +356,14 @@ class FCTGeneration:
     def show_error(self,s):
         self.running=False
         self.error=True
-        Gtk.threads_enter()
+        Gdk.threads_enter()
         error_dlg = Gtk.MessageDialog(
             self.dialog,
             Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
             Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,s)
         error_dlg.run()
         error_dlg.destroy()
-        Gtk.threads_leave()
+        Gdk.threads_leave()
         event = Gdk.Event(Gdk.DELETE)
         self.dialog.emit('delete_event', event)
     

--- a/fract4dgui/FCTGen.py
+++ b/fract4dgui/FCTGen.py
@@ -9,29 +9,26 @@
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
 # version 2.1 of the License, or (at your option) any later version.
-#                                                                             
+#
 # This library is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
-#                                                                             
+#
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
 # USA
 
 
-
-from gi.repository import Gtk
-from gi.repository import GObject
-import re
 import math
-import sys
 import os
-import math
-from fract4d import animation, fractal, fc, fractconfig
 
-class FCTGeneration:    
+from gi.repository import Gtk, GObject
+
+from fract4d import fractal, fc, fractconfig
+
+class FCTGeneration:
     def __init__(self,dir_bean,parent):
         self.dialog=Gtk.Dialog(
             "Generating .fct files...",parent,
@@ -52,7 +49,7 @@ class FCTGeneration:
             self.show_error("Could not find gnofract4d version. Can not continue")
             yield False
             return
-        #-------------loads gnofract4d libs----------------------------
+        # -------------loads gnofract4d libs----------------------------
         try:
             self.fractal=fractal
             self.compiler=fc.Compiler()
@@ -64,8 +61,8 @@ class FCTGeneration:
             self.show_error("Gnofract4d libs could not be found")
             yield False
             return
-        #--------------------------------------------------------------
-        #find values from base keyframe first
+        # --------------------------------------------------------------
+        # find values from base keyframe first
         try:
             ret=self.find_values(self.dir_bean.get_base_keyframe())
             if len(ret)==11:
@@ -79,7 +76,7 @@ class FCTGeneration:
             yield False
             return
         try:
-            #find values and duration from all keyframes
+            # find values and duration from all keyframes
             for i in range(self.dir_bean.keyframes_count()):
                 ret=self.find_values(self.dir_bean.get_keyframe_filename(i))
                 if len(ret)==11:
@@ -93,14 +90,14 @@ class FCTGeneration:
                     yield False
                     return
                 self.durations.append(self.dir_bean.get_keyframe_duration(i))
-            #interpolate and write .fct files
+            # interpolate and write .fct files
             for i in range(self.dir_bean.keyframes_count()):
-                if self.running==False:
+                if self.running is False:
                     yield False
                     break
                 self.write_fct_file(i)
                 percent=float(i+1)/float(self.dir_bean.keyframes_count())
-                if self.running==False:
+                if self.running is False:
                     break
                 self.pbar.set_fraction(percent)
                 self.pbar.set_text(str(percent*100)+"%")
@@ -110,10 +107,10 @@ class FCTGeneration:
             yield False
             return
             
-        if self.running==False:
+        if self.running is False:
             yield False
             return
-        self.running=False
+        self.running = False
         self.dialog.destroy()
         yield False
 
@@ -130,7 +127,7 @@ class FCTGeneration:
         pipe.close()
         return version
             
-    #finding x,y,z,w,size values from argument file and returns them as tuple
+    # finding x,y,z,w,size values from argument file and returns them as tuple
     def find_values(self,file):
         f=self.fractal.T(self.compiler)
         f.loadFctFile(open(file))
@@ -147,18 +144,18 @@ class FCTGeneration:
         zw=f.params[f.ZWANGLE]
         return (x,y,z,w,size,xy,xz,xw,yz,yw,zw)
     
-    #interpolate values and writes .fct files
+    # interpolate values and writes .fct files
     def write_fct_file(self,iteration):
-        #sum of all frames, needed for padding output files
+        # sum of all frames, needed for padding output files
         sumN=sum(self.durations)
         lenN=len(str(sumN))
         sumBefore=sum(self.durations[0:iteration])
-        #current duration
+        # current duration
         N=self.durations[iteration]
-        #get content of file
+        # get content of file
         f=self.fractal.T(self.compiler)
         f.loadFctFile(open(self.dir_bean.get_base_keyframe()))
-        #get all values
+        # get all values
         x1=float(self.values[iteration][f.XCENTER])
         x2=float(self.values[iteration+1][f.XCENTER])
         y1=float(self.values[iteration][f.YCENTER])
@@ -181,9 +178,9 @@ class FCTGeneration:
         yw2=float(self.values[iteration+1][f.YWANGLE])
         zw1=float(self.values[iteration][f.ZWANGLE])
         zw2=float(self.values[iteration+1][f.ZWANGLE])
-        #------------find direction for angles----------------------
+        # ------------find direction for angles----------------------
         to_right=[False]*6
-        #----------xy--------------
+        # ----------xy--------------
         dir_xy=self.dir_bean.get_directions(iteration)[0]
         if dir_xy==0:
             if abs(xy2-xy1)<math.pi and xy1<xy2:
@@ -197,12 +194,12 @@ class FCTGeneration:
                 to_right[0]=True
         elif dir_xy==2:
             to_right[0]=True
-        if to_right[0]==True and xy2<xy1:
+        if to_right[0] is True and xy2<xy1:
                 xy2=xy2+2*math.pi
-        if to_right[0]==False and xy2>xy1:
+        if to_right[0] is False and xy2>xy1:
                 xy1=xy1+2*math.pi
-        #--------------------------
-        #----------xz--------------
+        # --------------------------
+        # ----------xz--------------
         dir_xz=self.dir_bean.get_directions(iteration)[1]
         if dir_xz==0:
             if abs(xz2-xz1)<math.pi and xz1<xz2:
@@ -216,12 +213,12 @@ class FCTGeneration:
                 to_right[1]=True
         elif dir_xz==2:
             to_right[1]=True
-        if to_right[1]==True and xz2<xz1:
+        if to_right[1] is True and xz2<xz1:
                 xz2=xz2+2*math.pi
-        if to_right[1]==False and xz2>xz1:
+        if to_right[1] is False and xz2>xz1:
                 xz1=xz1+2*math.pi
-        #--------------------------
-        #----------xw--------------
+        # --------------------------
+        # ----------xw--------------
         dir_xw=self.dir_bean.get_directions(iteration)[2]
         if dir_xw==0:
             if abs(xw2-xw1)<math.pi and xw1<xw2:
@@ -235,12 +232,12 @@ class FCTGeneration:
                 to_right[2]=True
         elif dir_xw==2:
             to_right[2]=True
-        if to_right[2]==True and xw2<xw1:
+        if to_right[2] is True and xw2<xw1:
                 xw2=xw2+2*math.pi
-        if to_right[2]==False and xw2>xw1:
+        if to_right[2] is False and xw2>xw1:
                 xw1=xw1+2*math.pi
-        #--------------------------
-        #----------yz--------------
+        # --------------------------
+        # ----------yz--------------
         dir_yz=self.dir_bean.get_directions(iteration)[3]
         if dir_yz==0:
             if abs(yz2-yz1)<math.pi and yz1<yz2:
@@ -254,12 +251,12 @@ class FCTGeneration:
                 to_right[3]=True
         elif dir_yz==2:
             to_right[3]=True
-        if to_right[3]==True and yz2<yz1:
+        if to_right[3] is True and yz2<yz1:
                 yz2=yz2+2*math.pi
-        if to_right[3]==False and yz2>yz1:
+        if to_right[3] is False and yz2>yz1:
                 yz1=yz1+2*math.pi
-        #--------------------------
-        #----------yw--------------
+        # --------------------------
+        # ----------yw--------------
         dir_yw=self.dir_bean.get_directions(iteration)[4]
         if dir_yw==0:
             if abs(yw2-yw1)<math.pi and yw1<yw2:
@@ -273,12 +270,12 @@ class FCTGeneration:
                 to_right[4]=True
         elif dir_yw==2:
             to_right[4]=True
-        if to_right[4]==True and yw2<yw1:
+        if to_right[4] is True and yw2<yw1:
                 yw2=yw2+2*math.pi
-        if to_right[4]==False and yw2>yw1:
+        if to_right[4] is False and yw2>yw1:
                 yw1=yw1+2*math.pi
-        #--------------------------
-        #----------zw--------------
+        # --------------------------
+        # ----------zw--------------
         dir_zw=self.dir_bean.get_directions(iteration)[5]
         if dir_zw==0:
             if abs(zw2-zw1)<math.pi and zw1<zw2:
@@ -292,14 +289,14 @@ class FCTGeneration:
                 to_right[5]=True
         elif dir_zw==2:
             to_right[5]=True
-        if to_right[5]==True and zw2<zw1:
+        if to_right[5] is True and zw2<zw1:
                 zw2=zw2+2*math.pi
-        if to_right[5]==False and zw2>zw1:
+        if to_right[5] is False and zw2>zw1:
                 zw1=zw1+2*math.pi
-        #--------------------------
-        #------------------------------------------------------------
+        # --------------------------
+        # ------------------------------------------------------------
         for i in range(N+1):
-            #depending on interpolation type, mu constant get different values from 0 to 1
+            # depending on interpolation type, mu constant get different values from 0 to 1
             int_type=self.dir_bean.get_keyframe_int(iteration)
             mu=float(i)/float(N)
             if int_type==INT_LINEAR:
@@ -310,7 +307,7 @@ class FCTGeneration:
                 mu=(math.exp(mu)-1)/(math.e-1)
             else:
                 mu=(1-math.cos(mu*math.pi))/2
-            #calculating new values
+            # calculating new values
             new_x=x1*(1-mu)+x2*mu
             new_y=y1*(1-mu)+y2*mu
             new_z=z1*(1-mu)+z2*mu
@@ -334,7 +331,7 @@ class FCTGeneration:
             new_zw=zw1*(1-mu)+zw2*mu
             while new_zw>math.pi:
                 new_zw=new_zw-2*math.pi
-            #replacing them in fractal
+            # replacing them in fractal
             f.params[f.XCENTER]=new_x
             f.params[f.YCENTER]=new_y
             f.params[f.ZCENTER]=new_z
@@ -346,7 +343,7 @@ class FCTGeneration:
             f.params[f.YZANGLE]=new_yz
             f.params[f.YWANGLE]=new_yw
             f.params[f.ZWANGLE]=new_zw
-            #writes .fct file
+            # writes .fct file
             folder=self.dir_bean.get_fct_dir()
             if folder[-1]!="/":
                 folder=folder+"/"
@@ -364,7 +361,7 @@ class FCTGeneration:
         error_dlg.run()
         error_dlg.destroy()
         Gdk.threads_leave()
-        event = Gdk.Event(Gdk.DELETE)
+        event = Gdk.Event(Gdk.EventType.DELETE)
         self.dialog.emit('delete_event', event)
     
     def show(self):
@@ -375,18 +372,18 @@ class FCTGeneration:
         GObject.idle_add(task.__next__)
         response = self.dialog.run()
         if response != Gtk.ResponseType.CANCEL:
-            if self.running==True: #destroy by user
+            if self.running is True:  # destroy by user
                 self.running=False
                 self.dialog.destroy()
                 return 1
             else:
-                if self.error==True: #error
+                if self.error is True:  # error
                     self.dialog.destroy()
                     return -1
-                else: #everything ok
+                else:  # everything ok
                     self.dialog.destroy()
                     return 0
-        else: #cancel pressed
+        else:  # cancel pressed
             self.running=False
             self.dialog.destroy()
             return 1

--- a/fract4dgui/PNGGen.py
+++ b/fract4dgui/PNGGen.py
@@ -1,18 +1,15 @@
-#UI and logic for generation PNG images
-#It gets all information from director bean class, gets all values, and,
-#in special thread, while it finds in-between values it call gtkfractal.HighResolution
-#to create images
+# UI and logic for generation PNG images
+# It gets all information from director bean class, gets all values, and,
+# in special thread, while it finds in-between values it call gtkfractal.HighResolution
+# to create images
 
-import re
-import math
-import sys
 import os
 from threading import *
 
-from gi.repository import Gdk, Gtk, GObject, GLib
+from gi.repository import Gdk, Gtk, GLib
 
 from . import gtkfractal, hig
-from fract4d import fractal,fracttypes, animation
+from fract4d import fractal
 
 running=False
 thread_error=False
@@ -41,14 +38,14 @@ class PNGGeneration(Gtk.Dialog,hig.MessagePopper):
         self.set_geometry_hints(None, geometry, Gdk.WindowHints.ASPECT)
         self.anim=animation
 
-        #-------------loads compiler----------------------------
+        # -------------loads compiler----------------------------
         self.compiler=compiler
 
     def generate_png(self):
         global running
         durations=[]
 
-        #--------find values and duration from all keyframes------------
+        # --------find values and duration from all keyframes------------
         try:
             durations = self.anim.get_keyframe_durations()
         except Exception as err:
@@ -56,7 +53,7 @@ class PNGGeneration(Gtk.Dialog,hig.MessagePopper):
             yield False
             return
 
-        #---------------------------------------------------------------
+        # ---------------------------------------------------------------
         create_all_images=self.to_create_images_again()
         gt=GenerationThread(
             durations,self.anim,
@@ -69,13 +66,12 @@ class PNGGeneration(Gtk.Dialog,hig.MessagePopper):
             working=gt.isAlive()
             yield True
 
-        if thread_error==True:
+        if thread_error is True:
             self.show_error("Error during image generation", "Unknown")
             yield False
             return
 
-
-        if running==False:
+        if running is False:
             yield False
             return
         running=False
@@ -110,7 +106,6 @@ class PNGGeneration(Gtk.Dialog,hig.MessagePopper):
         return create
 
     def show_error(self,message,secondary):
-        running=False
         self.error=True
         Gdk.threads_enter()
         error_dlg = hig.ErrorAlert(
@@ -120,7 +115,7 @@ class PNGGeneration(Gtk.Dialog,hig.MessagePopper):
         error_dlg.run()
         error_dlg.destroy()
         Gdk.threads_leave()
-        event = Gdk.Event(Gdk.DELETE)
+        event = Gdk.Event(Gdk.EventType.DELETE)
         self.emit('delete_event', event)
 
     def show(self):
@@ -132,34 +127,34 @@ class PNGGeneration(Gtk.Dialog,hig.MessagePopper):
         GLib.idle_add(task.__next__)
         response = self.run()
         if response != Gtk.ResponseType.CANCEL:
-            if running==True: #destroy by user
+            if running is True:  # destroy by user
                 running=False
                 self.destroy()
                 return 1
             else:
-                if self.error==True: #error
+                if self.error is True:  # error
                     self.destroy()
                     return -1
-                else: #everything ok
+                else:  # everything ok
                     self.destroy()
                     return 0
-        else: #cancel pressed
+        else:  # cancel pressed
             running=False
             self.destroy()
             return 1
 
-#thread to interpolate values and calls generation of .png files
+# thread to interpolate values and calls generation of .png files
 class GenerationThread(Thread):
     def __init__(
-        self,durations,animation,compiler,
-        create_all_images,pbar_image,pbar_overall):
+            self,durations,animation,compiler,
+            create_all_images,pbar_image,pbar_overall):
         Thread.__init__(self)
         self.durations=durations
         self.anim=animation
         self.create_all_images=create_all_images
         self.pbar_image=pbar_image
         self.pbar_overall=pbar_overall
-        #initializing progress bars
+        # initializing progress bars
         self.pbar_image.set_fraction(0)
         self.pbar_overall.set_fraction(0)
         self.pbar_overall.set_text("0/"+str(sum(self.durations)+1))
@@ -172,7 +167,7 @@ class GenerationThread(Thread):
         self.current.connect('status-changed', self.onStatusChanged)
         self.current.connect('progress-changed', self.onProgressChanged)
 
-        #semaphore to signalize that image generation is finished
+        # semaphore to signalize that image generation is finished
         self.next_image=Semaphore(1)
 
     def onProgressChanged(self,f,progress):
@@ -180,26 +175,26 @@ class GenerationThread(Thread):
         if running:
             self.pbar_image.set_fraction(progress/100.0)
 
-    #one image generation complete - tell (with "semaphore" self.next_image) we can continue
+    # one image generation complete - tell (with "semaphore" self.next_image) we can continue
     def onStatusChanged(self,f,status_val):
         if status_val == 0:
-            #release semaphore
+            # release semaphore
             self.next_image.release()
 
     def run(self):
         global thread_error,running
         import traceback
         try:
-            #first generates image from base keyframe
+            # first generates image from base keyframe
             self.generate_base_keyframe()
-            #pass through all keyframes and generates inter images
+            # pass through all keyframes and generates inter images
             for i in range(self.anim.keyframes_count()-1):
                 self.generate_images(i)
-                if running==False:
+                if running is False:
                     return
-            #wait for last image to finish rendering
+            # wait for last image to finish rendering
             self.next_image.acquire()
-            #generate list file
+            # generate list file
             lfilename = os.path.join(self.anim.get_png_dir(), "list")
             with open(lfilename, "w") as lfile:
                 for imagefile in self.anim.create_list():
@@ -211,7 +206,6 @@ class GenerationThread(Thread):
             running=False
             return
 
-
     def generate_base_keyframe(self):
         f=fractal.T(self.compiler)
         fh = open(self.anim.get_keyframe_filename(0))
@@ -221,33 +215,32 @@ class GenerationThread(Thread):
             fh.close()
         
         self.next_image.acquire()
-        #writes .fct file if user wanted that
+        # writes .fct file if user wanted that
         if self.anim.get_fct_enabled():
             f.save(open(self.anim.get_fractal_filename(0),"w"))
-        #check if image already exist and user wants to leave it or not
-        if not(os.path.exists(self.anim.get_image_filename(0)) and self.create_all_images==False): #check if image already exist
+        #  check if image already exist and user wants to leave it or not
+        if not(os.path.exists(self.anim.get_image_filename(0)) and self.create_all_images is False):  # check if image already exist
             self.current.set_fractal(f)
             self.current.reset_render()
             self.current.draw_image(self.anim.get_image_filename(0))
         else:
-            #just release semaphore
+            # just release semaphore
             self.next_image.release()
         return
 
-    #main method for generating images
-    #it generates images between iteration-th-1 and iteration-th keyframe
-    #first, it gets border values (keyframe values)
-    #(values - x,y,z,w,size,angles,formula parameters)
-    #then, in a loop, it generates inter values, fill fractal class with it and
-    #calls gtkfractal.HighResolution to generate images
+    # main method for generating images
+    # it generates images between iteration-th-1 and iteration-th keyframe
+    # first, it gets border values (keyframe values)
+    # (values - x,y,z,w,size,angles,formula parameters)
+    # then, in a loop, it generates inter values, fill fractal class with it and
+    # calls gtkfractal.HighResolution to generate images
     def generate_images(self,iteration):
         global running
-        #sum of all frames, needed for padding output files
+        # sum of all frames, needed for padding output files
         sumN=sum(self.durations)
-        lenN=len(str(sumN))
-        #number of images already generated
+        # number of images already generated
         sumBefore=sum(self.durations[0:iteration])
-        #current duration
+        # current duration
         N=self.durations[iteration]
 
         f_prev=fractal.T(self.compiler)
@@ -264,15 +257,15 @@ class GenerationThread(Thread):
         finally:
             fh.close()
             
-        #------------------------------------------------------------
-        #loop to generate images between current (iteration-th) and previous keyframe
+        # ------------------------------------------------------------
+        # loop to generate images between current (iteration-th) and previous keyframe
         for i in range(1,N+1):
-            #but, first, wait for previous image to finish rendering
+            # but, first, wait for previous image to finish rendering
             self.next_image.acquire()
-            #check if user canceled us
-            if running==False:
+            # check if user canceled us
+            if running is False:
                 return
-            #update progress bar
+            # update progress bar
             percent=float((sumBefore+i))/(sumN+1)
             self.pbar_overall.set_fraction(percent)
             self.pbar_overall.set_text(str(sumBefore+i)+"/"+str(sumN+1))
@@ -282,16 +275,16 @@ class GenerationThread(Thread):
             mu=self.anim.get_mu(int_type, float(i)/float(N))
             f_frame = f_prev.blend(f_next,mu)
 
-            #writes .fct file if user wanted that
+            # writes .fct file if user wanted that
             if self.anim.get_fct_enabled():
                 f_frame.save(open(self.anim.get_fractal_filename(sumBefore+i),"w"))
 
-            #check if image already exist and user wants to leave it or not
-            if not(os.path.exists(self.anim.get_image_filename(sumBefore+i)) and self.create_all_images==False): #check if image already exist
+            # check if image already exist and user wants to leave it or not
+            if not(os.path.exists(self.anim.get_image_filename(sumBefore+i)) and self.create_all_images is False):  # check if image already exist
                 self.current.set_fractal(f_frame)
                 self.current.reset_render()
                 self.current.draw_image(self.anim.get_image_filename(sumBefore+i))
             else:
-                #just release semaphore
+                # just release semaphore
                 self.next_image.release()
         return

--- a/fract4dgui/PNGGen.py
+++ b/fract4dgui/PNGGen.py
@@ -86,7 +86,7 @@ class PNGGeneration(Gtk.Dialog,hig.MessagePopper):
         filelist = self.anim.create_list()
         for f in filelist:
             if os.path.exists(f):
-                Gtk.threads_enter()
+                Gdk.threads_enter()
                 try:
                     folder_png = self.anim.get_png_dir()
                     response = self.ask_question(
@@ -95,10 +95,10 @@ class PNGGeneration(Gtk.Dialog,hig.MessagePopper):
 
                 except Exception as err:
                     print(err)
-                    Gtk.threads_leave()
+                    Gdk.threads_leave()
                     raise
 
-                Gtk.threads_leave()
+                Gdk.threads_leave()
             
                 if response==Gtk.ResponseType.ACCEPT:
                     create=False

--- a/fract4dgui/PNGGen.py
+++ b/fract4dgui/PNGGen.py
@@ -200,11 +200,10 @@ class GenerationThread(Thread):
             #wait for last image to finish rendering
             self.next_image.acquire()
             #generate list file
-            list = self.anim.create_list()
             lfilename = os.path.join(self.anim.get_png_dir(), "list")
-            lfile = open(lfilename,"w")
-            print("\n".join(list), file=lfile)
-            lfile.close()
+            with open(lfilename, "w") as lfile:
+                for imagefile in self.anim.create_list():
+                    print("file '%s'" % imagefile, file=lfile)
             
         except:
             traceback.print_exc()

--- a/fract4dgui/PNGGen.py
+++ b/fract4dgui/PNGGen.py
@@ -18,9 +18,10 @@ running=False
 thread_error=False
 
 class PNGGeneration(Gtk.Dialog,hig.MessagePopper):
-    def __init__(self,animation,compiler):
+    def __init__(self, animation, compiler, parent):
         Gtk.Dialog.__init__(
             self,
+            transient_for=parent,
             title="Generating images...",
             modal=True, destroy_with_parent=True)
 

--- a/fract4dgui/angle.py
+++ b/fract4dgui/angle.py
@@ -35,7 +35,7 @@ class T(Gtk.DrawingArea):
             Gdk.EventMask.BUTTON1_MOTION_MASK |
             Gdk.EventMask.POINTER_MOTION_HINT_MASK |
             Gdk.EventMask.ENTER_NOTIFY_MASK |
-            Gdk.EventMask.LEAVE_NOTIFY_MASK |                               
+            Gdk.EventMask.LEAVE_NOTIFY_MASK |
             Gdk.EventMask.BUTTON_PRESS_MASK |
             Gdk.EventMask.EXPOSURE_MASK
             )
@@ -51,7 +51,7 @@ class T(Gtk.DrawingArea):
         self.adjustment.set_value(val)
         self.queue_draw()
         
-    def update_from_mouse(self,x,y):        
+    def update_from_mouse(self,x,y):
         (w,h) = (self.get_allocated_width(), self.get_allocated_height())
         
         xc = w//2
@@ -74,13 +74,11 @@ class T(Gtk.DrawingArea):
     def onMotionNotify(self,widget,event):
         if not self.notice_mouse:
             return
-        dummy = widget.get_pointer()
         self.update_from_mouse(event.x, event.y)
 
     def onButtonRelease(self,widget,event):
-        if event.button==1:
+        if event.button == 1:
             self.notice_mouse = False
-            (xc,yc) = (widget.get_allocated_width()//2, widget.get_allocated_height()//2)
             current_value = self.adjustment.get_value()
             if self.old_value != current_value:
                 self.old_value = current_value
@@ -88,7 +86,6 @@ class T(Gtk.DrawingArea):
 
         self.set_state(Gtk.StateType.NORMAL)
 
-        
     def onButtonPress(self,widget,event):
         if event.button == 1:
             self.notice_mouse = True

--- a/fract4dgui/autozoom.py
+++ b/fract4dgui/autozoom.py
@@ -7,17 +7,13 @@ from gi.repository import Gtk
 
 from . import dialog
 
-def show_autozoom(parent,f):
-    AutozoomDialog.show(parent,f)
-    
 class AutozoomDialog(dialog.T):
     def __init__(self,main_window,f):
         dialog.T.__init__(
             self,
             _("Autozoom"),
             main_window,
-            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True
+            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
         )
 
         self.f = f
@@ -58,11 +54,8 @@ class AutozoomDialog(dialog.T):
         self.table.attach(self.minsize_entry,
                           1,2,1,2,
                           Gtk.AttachOptions.EXPAND | Gtk.AttachOptions.FILL, 0, 2, 2)
-
-    def show(parent, f):
-        dialog.T.reveal(AutozoomDialog, True, parent, None, f)
-
-    show = staticmethod(show)
+        
+        self.vbox.show_all()
 
     def onResponse(self,widget,id):
         self.zoombutton.set_active(False)

--- a/fract4dgui/browser.py
+++ b/fract4dgui/browser.py
@@ -38,7 +38,7 @@ class BrowserDialog(dialog.T):
 
         self.set_default_response(Gtk.ResponseType.OK)
 
-        self.model = browser_model.instance
+        self.model = browser_model.T(main_window.compiler)
         self.model.type_changed += self.on_type_changed
         self.model.file_changed += self.on_file_changed
         self.model.formula_changed += self.on_formula_changed

--- a/fract4dgui/dialog.py
+++ b/fract4dgui/dialog.py
@@ -2,8 +2,6 @@
 
 from gi.repository import Gtk
 
-_dialogs = {}
-
 def make_label_box(parent, title):
     label_box = Gtk.HBox()
     label_box.set_name('dialog_label_box')
@@ -17,48 +15,18 @@ def make_label_box(parent, title):
     return label_box
 
 class T(Gtk.Dialog):
-    def __init__(self, title=None, parent=None, buttons=None,**kwds):
-        Gtk.Dialog.__init__(self, title=title, transient_for=parent, **kwds)
+    def __init__(self, title=None, parent=None, buttons=None, modal=True):
+        Gtk.Dialog.__init__(self,
+            title=title,
+            transient_for=parent,
+            modal=modal,
+            destroy_with_parent=True)
 
         if buttons:
                 self.add_buttons(*buttons)
 
         self.set_default_response(Gtk.ResponseType.CLOSE)
         self.connect('response',self.onResponse)
-
-        self.connect('destroy-event', self.clear_global)
-        self.connect('delete-event', self.clear_global)
-
-    def clear_global(self,*args):
-        global _dialogs
-        _dialogs[self.__class__] = None
-    
-    def reveal(type, dialog_mode, parent, alt_parent, *args):
-        global _dialogs
-        if not _dialogs.get(type):
-            _dialogs[type] = type(parent, *args)
-        if dialog_mode:
-            _dialogs[type].show_all()
-            _dialogs[type].present()
-        else:
-            if not hasattr(alt_parent, "dialogs"):
-                alt_parent.dialogs = {}
-            container = alt_parent.dialogs.get(type)
-            if not container:                
-                dialog = _dialogs[type]
-                box = dialog.controls
-                title = dialog.get_title()
-                container = make_container(title)
-                box.reparent(container)
-                alt_parent.pack_start(container,True,True,0)
-                alt_parent.dialogs[type] = container
-
-            container.show_all()
-            _dialogs[type].hide()
-        
-        return _dialogs[type]
-    
-    reveal = staticmethod(reveal)
 
     def onResponse(self,widget,id):
         if id == Gtk.ResponseType.CLOSE or \
@@ -67,7 +35,3 @@ class T(Gtk.Dialog):
             self.hide()
         else:
             print("unexpected response %d" % id)
-
-def get(type):
-    global _dialogs
-    return _dialogs.get(type)

--- a/fract4dgui/dialog.py
+++ b/fract4dgui/dialog.py
@@ -4,18 +4,17 @@ from gi.repository import Gtk
 
 _dialogs = {}
 
-def make_container(title):
+def make_label_box(parent, title):
     label_box = Gtk.HBox()
     label_box.set_name('dialog_label_box')
     label = Gtk.Label(label=title)
     label_box.pack_start(label, False, False, 0)
     close = Gtk.Button.new_from_stock(Gtk.STOCK_CLOSE)
     label_box.pack_end(close, False, False, 0)
-    frame = Gtk.VBox()
-    frame.pack_start(label_box, False, False, 1)
+    label_box.show_all()
 
-    close.connect('clicked', lambda x : frame.hide())
-    return frame
+    close.connect('clicked', lambda x : parent.hide())
+    return label_box
 
 class T(Gtk.Dialog):
     def __init__(self, title=None, parent=None, buttons=None,**kwds):

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -131,6 +131,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         dialog = Gtk.FileChooserDialog("Save AVI file...",self,Gtk.FileChooserAction.SAVE,
             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
         dialog.set_default_response(Gtk.ResponseType.OK)
+        dialog.set_filename(self.txt_temp_avi.get_text())
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
             temp_file=dialog.get_filename()
@@ -188,9 +189,8 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
 
     def temp_avi_clicked(self,widget, data=None):
         avi=self.get_avi_file()
-        if avi!="":
+        if avi:
             self.txt_temp_avi.set_text(avi)
-            self.animation.set_avi_file(avi)
 
     def output_width_changed(self,widget,data=None):
         self.animation.set_width(self.spin_width.get_value())
@@ -623,7 +623,6 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.box_output_file.pack_start(self.lbl_temp_avi,False,False,10)
 
         self.txt_temp_avi = Gtk.Entry()
-        self.txt_temp_avi.set_editable(False)
         self.box_output_file.pack_start(self.txt_temp_avi,True,True,10)
 
         self.btn_temp_avi=Gtk.Button(label="Browse")
@@ -706,7 +705,8 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
                id == Gtk.ResponseType.DELETE_EVENT:
             self.hide()
         elif id == DirectorDialog.RESPONSE_RENDER:
-            self.generate(self.transpath != None)
+            self.animation.set_avi_file(self.txt_temp_avi.get_text())
+            self.generate(self.converterpath is not None)
 
     def main(self):
         Gtk.main()

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -105,7 +105,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
     #returns selected file or empty string
     def get_fct_file(self):
         temp_file=""
-        dialog = Gtk.FileChooserDialog("Choose keyframe...",None,Gtk.FileChooserAction.OPEN,
+        dialog = Gtk.FileChooserDialog("Choose keyframe...",self,Gtk.FileChooserAction.OPEN,
             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
         dialog.set_default_response(Gtk.ResponseType.OK)
         #----setting filters---------
@@ -128,7 +128,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
     #returns selected file or empty string
     def get_avi_file(self):
         temp_file=""
-        dialog = Gtk.FileChooserDialog("Save AVI file...",None,Gtk.FileChooserAction.SAVE,
+        dialog = Gtk.FileChooserDialog("Save AVI file...",self,Gtk.FileChooserAction.SAVE,
             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
         dialog.set_default_response(Gtk.ResponseType.OK)
         response = dialog.run()
@@ -141,7 +141,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
     #returns selected file or empty string
     def get_cfg_file_save(self):
         temp_file=""
-        dialog = Gtk.FileChooserDialog("Save animation...",None,Gtk.FileChooserAction.SAVE,
+        dialog = Gtk.FileChooserDialog("Save animation...",self,Gtk.FileChooserAction.SAVE,
             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
         dialog.set_default_response(Gtk.ResponseType.OK)
         dialog.set_current_name("animation.fcta")
@@ -165,7 +165,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
     #returns selected file or empty string
     def get_cfg_file_open(self):
         temp_file=""
-        dialog = Gtk.FileChooserDialog("Choose animation...",None,Gtk.FileChooserAction.OPEN,
+        dialog = Gtk.FileChooserDialog("Choose animation...",self,Gtk.FileChooserAction.OPEN,
             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
         dialog.set_default_response(Gtk.ResponseType.OK)
         #----setting filters---------
@@ -230,7 +230,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         except UserCancelledError:
         	return
 
-        png_gen=PNGGen.PNGGeneration(self.animation, self.compiler)
+        png_gen=PNGGen.PNGGeneration(self.animation, self.compiler, self)
         res=png_gen.show()
         if res==1:
             # user cancelled, but they know that. Stop silently
@@ -242,7 +242,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         if not create_avi:
             return
 
-        avi_gen=AVIGen.AVIGeneration(self.animation)
+        avi_gen=AVIGen.AVIGeneration(self.animation, self)
         res=avi_gen.show()
         if res==1:
             # user cancelled, but they know that. Stop silently
@@ -259,7 +259,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
     def adv_opt_clicked(self,widget,data=None):
         if self.current_select==-1:
             return
-        dlg=DlgAdvOpt.DlgAdvOptions(self.current_select,self.animation)
+        dlg=DlgAdvOpt.DlgAdvOptions(self.current_select,self.animation,self)
         res=dlg.show()
 
     #before selecting keyframes in list box we must update values of spin boxes in case user typed something in there
@@ -433,7 +433,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
                     str(err))
 
     def preferences_clicked(self,widget,data=None):
-        dlg=director_prefs.DirectorPrefs(self.animation)
+        dlg=director_prefs.DirectorPrefs(self.animation, self)
         res=dlg.show()
 
     #creating window...

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -1,19 +1,14 @@
-#UI for gathering needed data and storing them in director bean class
-#then it calls PNGGeneration, and (if everything was OK) AVIGeneration
+# UI for gathering needed data and storing them in director bean class
+# then it calls PNGGeneration, and (if everything was OK) AVIGeneration
 
-#TODO: change default directory when selecting new according to already set item
-#(for temp dirs, avi and fct files selections)
-
-from gi.repository import Gdk
-from gi.repository import Gtk
-from gi.repository import GObject
-from gi.repository import GLib
+# TODO: change default directory when selecting new according to already set item
+# (for temp dirs, avi and fct files selections)
 
 import os
 import fnmatch
-import pickle
-import sys
 import tempfile
+
+from gi.repository import Gdk, Gtk, GObject
 
 from . import dialog, hig
 from fract4d import animation, fractconfig
@@ -21,7 +16,7 @@ from fract4d import animation, fractconfig
 from . import PNGGen,AVIGen,DlgAdvOpt,director_prefs
 
 class UserCancelledError(Exception):
-	pass
+    pass
 
 class SanityCheckError(Exception):
     "The type of exception which is thrown when animation sanity checks fail"
@@ -43,35 +38,35 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
                 _("Keyframe %s is in the temporary .fct directory and could be overwritten. Please change temp directory." % keyframe))
 
     def check_fct_file_sanity(self):
-        #things to check with fct temp dir
+        # things to check with fct temp dir
         if not self.animation.get_fct_enabled():
             # we're not generating .fct files, so this is superfluous
             return
 
-        #check fct temp dir is set
+        # check fct temp dir is set
         if self.animation.get_fct_dir()=="":
             raise SanityCheckError(
                 _("Directory for temporary .fct files not set"))
 
-        #check if it is directory
+        # check if it is directory
         if not os.path.isdir(self.animation.get_fct_dir()):
             raise SanityCheckError(
                 _("Path for temporary .fct files is not a directory"))
 
         fct_path=self.animation.get_fct_dir()
 
-        #check if any keyframe fct files are in temp fct dir
+        # heck if any keyframe fct files are in temp fct dir
         for i in range(self.animation.keyframes_count()):
             keyframe = self.animation.get_keyframe_filename(i)
             self.check_for_keyframe_clash(keyframe,fct_path)
 
-        #check if there are any .fct files in temp fct dir
+        # check if there are any .fct files in temp fct dir
         has_any=False
         for file in os.listdir(fct_path):
             if fnmatch.fnmatch(file,"*.fct"):
                 has_any=True
                 
-            if has_any==True:
+            if has_any is True:
                 response = self.ask_question(
                     _("Directory for temporary .fct files contains other .fct files"),
                     _("These may be overwritten. Proceed?"))
@@ -79,36 +74,36 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
                     raise UserCancelledError()
             return
 
-    #throws SanityCheckError if there was a problem
+    # throws SanityCheckError if there was a problem
     def check_sanity(self):
-        #check if at least two keyframes exist
+        # check if at least two keyframes exist
         if self.animation.keyframes_count()<2:
             raise SanityCheckError(_("There must be at least two keyframes"))
 
-        #check png temp dir is set
+        # check png temp dir is set
         if self.animation.get_png_dir()=="":
             raise SanityCheckError(
                 _("Directory for temporary .png files not set"))
 
-        #check if it is directory
+        # check if it is directory
         if not os.path.isdir(self.animation.get_png_dir()):
             raise SanityCheckError(
                 _("Path for temporary .png files is not a directory"))
 
-        #check avi file is set
+        # check avi file is set
         if self.animation.get_avi_file()=="":
             raise SanityCheckError(_("Output AVI file name not set"))
 
         self.check_fct_file_sanity()
 
-    #wrapper to show dialog for selecting .fct file
-    #returns selected file or empty string
+    # wrapper to show dialog for selecting .fct file
+    # returns selected file or empty string
     def get_fct_file(self):
         temp_file=""
         dialog = Gtk.FileChooserDialog("Choose keyframe...",self,Gtk.FileChooserAction.OPEN,
             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
         dialog.set_default_response(Gtk.ResponseType.OK)
-        #----setting filters---------
+        # ----setting filters---------
         filter = Gtk.FileFilter()
         filter.set_name("gnofract4d files (*.fct)")
         filter.add_pattern("*.fct")
@@ -117,15 +112,15 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         filter.set_name("All files")
         filter.add_pattern("*")
         dialog.add_filter(filter)
-        #----------------------------
+        # ----------------------------
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
             temp_file=dialog.get_filename()
         dialog.destroy()
         return temp_file
 
-    #wrapper to show dialog for selecting .avi file
-    #returns selected file or empty string
+    # wrapper to show dialog for selecting .avi file
+    # returns selected file or empty string
     def get_avi_file(self):
         temp_file=""
         dialog = Gtk.FileChooserDialog("Save AVI file...",self,Gtk.FileChooserAction.SAVE,
@@ -138,15 +133,15 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         dialog.destroy()
         return temp_file
 
-    #wrapper to show dialog for selecting .cfg file
-    #returns selected file or empty string
+    # wrapper to show dialog for selecting .cfg file
+    # returns selected file or empty string
     def get_cfg_file_save(self):
         temp_file=""
         dialog = Gtk.FileChooserDialog("Save animation...",self,Gtk.FileChooserAction.SAVE,
             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
         dialog.set_default_response(Gtk.ResponseType.OK)
         dialog.set_current_name("animation.fcta")
-        #----setting filters---------
+        # ----setting filters---------
         filter = Gtk.FileFilter()
         filter.set_name("gnofract4d animation files (*.fcta)")
         filter.add_pattern("*.fcta")
@@ -155,21 +150,21 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         filter.set_name("All files")
         filter.add_pattern("*")
         dialog.add_filter(filter)
-        #----------------------------
+        # ----------------------------
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
             temp_file=dialog.get_filename()
         dialog.destroy()
         return temp_file
 
-    #wrapper to show dialog for selecting .fct file
-    #returns selected file or empty string
+    # wrapper to show dialog for selecting .fct file
+    # returns selected file or empty string
     def get_cfg_file_open(self):
         temp_file=""
         dialog = Gtk.FileChooserDialog("Choose animation...",self,Gtk.FileChooserAction.OPEN,
             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
         dialog.set_default_response(Gtk.ResponseType.OK)
-        #----setting filters---------
+        # ----setting filters---------
         filter = Gtk.FileFilter()
         filter.set_name("gnofract4d animation files (*.fcta)")
         filter.add_pattern("*.fcta")
@@ -178,7 +173,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         filter.set_name("All files")
         filter.add_pattern("*")
         dialog.add_filter(filter)
-        #----------------------------
+        # ----------------------------
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
             temp_file=dialog.get_filename()
@@ -219,8 +214,8 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.animation.set_keyframe_int(self.current_select,int(self.cmb_interpolation_type.get_active()))
         self.update_model()
 
-    #point of whole program:)
-    #first we generate png files and list, then .avi
+    # point of whole program:)
+    # first we generate png files and list, then .avi
     def generate(self,create_avi=True):
         try:
             self.check_sanity()
@@ -228,7 +223,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
             self.show_error(_("Cannot Generate Animation"), str(exn))
             return
         except UserCancelledError:
-        	return
+            return
 
         png_gen=PNGGen.PNGGeneration(self.animation, self.compiler, self)
         res=png_gen.show()
@@ -260,22 +255,22 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         if self.current_select==-1:
             return
         dlg=DlgAdvOpt.DlgAdvOptions(self.current_select,self.animation,self)
-        res=dlg.show()
+        dlg.show()
 
-    #before selecting keyframes in list box we must update values of spin boxes in case user typed something in there
+    # before selecting keyframes in list box we must update values of spin boxes in case user typed something in there
     def before_selection(self, selection, data=None, *kwargs):
         self.spin_duration.update()
         self.spin_kf_stop.update()
         return True
 
-    #update right box (duration, stop, interpolation type) when keyframe is selected from list
+    # update right box (duration, stop, interpolation type) when keyframe is selected from list
     def selection_changed(self,widget, data=None):
         (model,it)=self.tv_keyframes.get_selection().get_selected()
-        if it!=None:
-            #------getting index of selected row-----------
+        if it is not None:
+            # ------getting index of selected row-----------
             index=0
             it=model.get_iter_first()
-            while it!=None:
+            while it is not None:
                 if self.tv_keyframes.get_selection().iter_is_selected(it):
                     break
                 it=model.iter_next(it)
@@ -293,11 +288,11 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
 
     def update_model(self):
         (model,it)=self.tv_keyframes.get_selection().get_selected()
-        if it!=None:
-            #------getting index of selected row-----------
+        if it is not None:
+            # ------getting index of selected row-----------
             index=0
             it=model.get_iter_first()
-            while it!=None:
+            while it is not None:
                 if self.tv_keyframes.get_selection().iter_is_selected(it):
                     break
                 it=model.iter_next(it)
@@ -332,25 +327,25 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
 
     def add_keyframe(self,file):
         if file!="":
-            #get current seletion
+            # get current seletion
             (model,it)=self.tv_keyframes.get_selection().get_selected()
-            if it==None: #if it's none, just append at the end of the list
+            if it is None:  # if it's none, just append at the end of the list
                 it=model.append([file,25,1,"Linear"])
-            else: #append after currently selected
+            else:  # append after currently selected
                 it=model.insert_after(it,[file,25,1,"Linear"])
 
-            #add to bean with default parameters
+            # add to bean with default parameters
             if self.current_select!=-1:
                 self.animation.add_keyframe(file,25,1,animation.INT_LINEAR,self.current_select+1)
             else:
                 self.animation.add_keyframe(file,25,1,animation.INT_LINEAR)
-            #and select newly item
+            # and select newly item
             self.tv_keyframes.get_selection().select_iter(it)
-            #set default duration
+            # set default duration
             self.spin_duration.set_value(25)
-            #set default stop
+            # set default stop
             self.spin_kf_stop.set_value(1)
-            #set default interpolation type
+            # set default interpolation type
             self.cmb_interpolation_type.set_active(animation.INT_LINEAR)
 
     def add_keyframe_clicked(self,widget, event):
@@ -363,15 +358,15 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         return False
 
     def remove_keyframe_clicked(self,widget,data=None):
-        #is anything selected
+        # is anything selected
         (model,it)=self.tv_keyframes.get_selection().get_selected()
-        if it!=None:
+        if it is not None:
             temp_curr=self.current_select
             model.remove(it)
             self.animation.remove_keyframe(temp_curr)
 
     def updateGUI(self):
-        #keyframes
+        # keyframes
         (model,it)=self.tv_keyframes.get_selection().get_selected()
         model.clear()
         for i in range(self.animation.keyframes_count()-1,-1,-1):
@@ -388,14 +383,14 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
                 model.set(it,3,"Inverse logarithmic")
             else:
                 model.set(it,3,"Cosine")
-        #output part
+        # output part
         self.txt_temp_avi.set_text(self.animation.get_avi_file())
         self.spin_width.set_value(self.animation.get_width())
         self.spin_height.set_value(self.animation.get_height())
         self.spin_framerate.set_value(self.animation.get_framerate())
         self.chk_swapRB.set_active(self.animation.get_redblue())
 
-    #loads configuration file, returns 0 on ok, -1 on error (and displays error message)
+    # loads configuration file, returns 0 on ok, -1 on error (and displays error message)
     def load_configuration(self,file):
         if file=="":
             return -1
@@ -406,27 +401,27 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
                 _("Cannot load animation"),
                 str(err))
             return -1
-        #set GUI to reflect changes
+        # set GUI to reflect changes
         self.updateGUI()
         return 0
 
-    #loads configuration from pickled file
+    # loads configuration from pickled file
     def load_configuration_clicked(self,widget,data=None):
         cfg=self.get_cfg_file_open()
         if cfg!="":
             self.load_configuration(cfg)
 
-    #reset all field to defaults
+    # reset all field to defaults
     def new_configuration_clicked(self,widget,data=None):
         self.animation.reset()
         self.updateGUI()
 
-    #save configuration in file
+    # save configuration in file
     def save_configuration_clicked(self,widget,data=None):
         cfg=self.get_cfg_file_save()
         if cfg!="":
             try:
-                result=self.animation.save_animation(cfg)
+                self.animation.save_animation(cfg)
             except Exception as err:
                 self.show_error(
                     _("Error saving animation"),
@@ -434,9 +429,9 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
 
     def preferences_clicked(self,widget,data=None):
         dlg=director_prefs.DirectorPrefs(self.animation, self)
-        res=dlg.show()
+        dlg.show()
 
-    #creating window...
+    # creating window...
     def __init__(self, main_window, f, conf_file=""):
         dialog.T.__init__(
             self,
@@ -451,9 +446,9 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.f=f
         self.compiler = f.compiler
 
-        #main VBox
+        # main VBox
         self.box_main=Gtk.VBox(False,0)
-        #--------------------menu-------------------------------
+        # --------------------menu-------------------------------
         self.manager = Gtk.UIManager()
         accelgroup = self.manager.get_accel_group()
         self.add_accel_group(accelgroup)
@@ -494,9 +489,8 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.menubar = self.manager.get_widget('/menubar')
         self.box_main.pack_start(self.menubar, False, True, 0)
 
-
-        #-----------creating popup menu-------------------------------
-        #popup menu for keyframes
+        # -----------creating popup menu-------------------------------
+        # popup menu for keyframes
         self.popup_menu=Gtk.Menu()
         self.mnu_pop_add_file=Gtk.MenuItem("From file")
         self.popup_menu.append(self.mnu_pop_add_file)
@@ -507,7 +501,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.mnu_pop_add_current.connect("activate", self.add_from_current, None)
         self.mnu_pop_add_current.show()
 
-        #--------------Keyframes box-----------------------------------
+        # --------------Keyframes box-----------------------------------
         self.frm_kf = Gtk.Frame.new("Keyframes")
         self.frm_kf.set_border_width(10)
         vbox_kfs = Gtk.Box.new(Gtk.Orientation.VERTICAL, 8)
@@ -611,8 +605,8 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.tbl_keyframes_right.attach(self.btn_adv_opt,0,2,3,4)
 
         self.current_kf.add(self.tbl_keyframes_right) #,False,False,10)
-        #-------------------------------------------------------------------
-        #----------------------output box-----------------------------------
+        # -------------------------------------------------------------------
+        # ----------------------output box-----------------------------------
         self.frm_output = Gtk.Frame.new("Output options")
         self.frm_output.set_border_width(10)
 
@@ -674,7 +668,6 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.frm_output.add(self.box_output_main)
         self.box_main.pack_start(self.frm_output,False,False,0)
 
-
         # check if video converter can be found
         self.converterpath = fractconfig.instance.find_on_path("ffmpeg")
         if not self.converterpath:
@@ -692,7 +685,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
             warning_box.pack_start(message, True, True, 0)
             self.box_main.pack_end(warning_box, True, True, 0)
 
-        #--------------showing all-------------------------------
+        # --------------showing all-------------------------------
         self.vbox.add(self.box_main)
         self.vbox.show_all()
         self.controls = self.vbox

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -640,7 +640,6 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         adj_width = Gtk.Adjustment.new(640,320,2048,10,100,0)
         self.spin_width = Gtk.SpinButton()
         self.spin_width.set_adjustment(adj_width)
-        self.spin_width.connect("output",self.output_width_changed,None)
         self.box_output_res.pack_start(self.spin_width,False,False,10)
 
         self.lbl_x=Gtk.Label(label="x")
@@ -649,7 +648,6 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         adj_height=Gtk.Adjustment.new(480,240,1536,10,100,0)
         self.spin_height = Gtk.SpinButton()
         self.spin_height.set_adjustment(adj_height)
-        self.spin_height.connect("output",self.output_height_changed,None)
         self.box_output_res.pack_start(self.spin_height,False,False,10)
 
         self.box_output_main.pack_start(self.box_output_res,True,True,0)
@@ -662,12 +660,9 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         adj_framerate = Gtk.Adjustment.new(25,5,100,1,5,0)
         self.spin_framerate = Gtk.SpinButton()
         self.spin_framerate.set_adjustment(adj_framerate)
-        self.spin_framerate.connect("output",self.output_framerate_changed,None)
         self.box_output_framerate.pack_start(self.spin_framerate,False,False,10)
 
         self.chk_swapRB=Gtk.CheckButton(label="Swap red and blue component")
-        self.chk_swapRB.set_active(True)
-        self.chk_swapRB.connect("toggled",self.swap_redblue_clicked,None)
         self.box_output_framerate.pack_start(self.chk_swapRB,False,False,50)
 
         self.box_output_main.pack_start(self.box_output_framerate,True,True,0)
@@ -692,12 +687,22 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
             warning_box.pack_start(message, True, True, 0)
             self.box_main.pack_end(warning_box, True, True, 0)
 
+        # initialise default settings
+        if conf_file:
+            self.load_configuration(conf_file)
+        else:
+            self.updateGUI()
+
+        # don't connect signals until after settings initialised
+        self.spin_height.connect("value-changed",self.output_height_changed,None)
+        self.spin_width.connect("value-changed",self.output_width_changed,None)
+        self.spin_framerate.connect("value-changed",self.output_framerate_changed,None)
+        self.chk_swapRB.connect("toggled",self.swap_redblue_clicked,None)
+
         # --------------showing all-------------------------------
         self.vbox.add(self.box_main)
         self.vbox.show_all()
         self.controls = self.vbox
-        if conf_file!="":
-            self.load_configuration(conf_file)
 
     def onResponse(self,widget,id):
         if id == Gtk.ResponseType.CLOSE or \

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -676,9 +676,9 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.box_main.pack_start(self.frm_output,False,False,0)
 
 
-        # check if transcode can be found
-        self.transpath = fractconfig.instance.find_on_path("transcode")
-        if not self.transpath:
+        # check if video converter can be found
+        self.converterpath = fractconfig.instance.find_on_path("ffmpeg")
+        if not self.converterpath:
             # put a message at the bottom to warn user
             warning_box = Gtk.HBox()
             image = Gtk.Image.new_from_stock(
@@ -687,7 +687,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
             warning_box.pack_start(image, True, True, 0)
             
             message = Gtk.Label(label=
-                _("Transcode utility not found. Without it we can't generate any video but can still save sequences of still images."))
+                _("ffmpeg utility not found. Without it we can't generate any video but can still save sequences of still images."))
 
             message.set_line_wrap(True)
             warning_box.pack_start(message, True, True, 0)

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -447,13 +447,14 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.compiler = f.compiler
 
         # main VBox
-        self.box_main=Gtk.VBox(False,0)
+        self.box_main=Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
+        self.box_main.set_homogeneous(False)
         # --------------------menu-------------------------------
         self.manager = Gtk.UIManager()
         accelgroup = self.manager.get_accel_group()
         self.add_accel_group(accelgroup)
 
-        actiongroup = Gtk.ActionGroup("Director")
+        actiongroup = Gtk.ActionGroup.new("Director")
         actiongroup.add_actions([
                 ('DirectorMenuAction', None, _('_Director')),
                 ('DirectorEditAction', None, _('_Edit')),
@@ -492,11 +493,11 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         # -----------creating popup menu-------------------------------
         # popup menu for keyframes
         self.popup_menu=Gtk.Menu()
-        self.mnu_pop_add_file=Gtk.MenuItem("From file")
+        self.mnu_pop_add_file=Gtk.MenuItem.new_with_label("From file")
         self.popup_menu.append(self.mnu_pop_add_file)
         self.mnu_pop_add_file.connect("activate", self.add_from_file, None)
         self.mnu_pop_add_file.show()
-        self.mnu_pop_add_current=Gtk.MenuItem("From current fractal")
+        self.mnu_pop_add_current=Gtk.MenuItem.new_with_label("From current fractal")
         self.popup_menu.append(self.mnu_pop_add_current)
         self.mnu_pop_add_current.connect("activate", self.add_from_current, None)
         self.mnu_pop_add_current.show()
@@ -525,7 +526,8 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
 #        self.tv_column_name.add_attribute(self.cell_duration, 'text', 0)
         filenames=Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_UINT,
                             GObject.TYPE_UINT, GObject.TYPE_STRING)
-        self.tv_keyframes = Gtk.TreeView(filenames)
+        self.tv_keyframes = Gtk.TreeView()
+        self.tv_keyframes.set_model(filenames)
         column = Gtk.TreeViewColumn('Keyframes', Gtk.CellRendererText(),text=0)
         self.tv_keyframes.append_column(column)
 
@@ -565,31 +567,33 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
 
         self.box_main.pack_start(self.current_kf,True,True,0)
 
-        self.tbl_keyframes_right=Gtk.Table(n_rows=4,n_columns=2,homogeneous=True)
-        self.tbl_keyframes_right.set_row_spacings(10)
-        self.tbl_keyframes_right.set_col_spacings(10)
+        self.tbl_keyframes_right = Gtk.Grid()
+        self.tbl_keyframes_right.set_column_homogeneous(True)
+        self.tbl_keyframes_right.set_row_homogeneous(True)
+        self.tbl_keyframes_right.set_row_spacing(10)
+        self.tbl_keyframes_right.set_column_spacing(10)
         self.tbl_keyframes_right.set_border_width(10)
 
-        self.lbl_duration=Gtk.Label(label="Duration")
-        self.tbl_keyframes_right.attach(self.lbl_duration,0,1,0,1)
+        self.lbl_duration = Gtk.Label(label="Duration:")
+        self.tbl_keyframes_right.attach(self.lbl_duration,0,0,1,1)
 
-        adj_duration = Gtk.Adjustment(25,1,10000,1,10)
+        adj_duration = Gtk.Adjustment.new(25,1,10000,1,10,0)
         self.spin_duration = Gtk.SpinButton()
         self.spin_duration.set_adjustment(adj_duration)
         self.spin_duration.connect("output",self.duration_changed,None)
-        self.tbl_keyframes_right.attach(self.spin_duration,1,2,0,1)
+        self.tbl_keyframes_right.attach(self.spin_duration,1,0,1,1)
 
         self.lbl_kf_stop=Gtk.Label(label="Keyframe stopped for:")
-        self.tbl_keyframes_right.attach(self.lbl_kf_stop,0,1,1,2)
+        self.tbl_keyframes_right.attach(self.lbl_kf_stop,0,1,1,1)
 
-        adj_kf_stop = Gtk.Adjustment(1,1,10000,1,10)
+        adj_kf_stop = Gtk.Adjustment.new(1,1,10000,1,10,0)
         self.spin_kf_stop = Gtk.SpinButton()
         self.spin_duration.set_adjustment(adj_kf_stop)
         self.spin_kf_stop.connect("output",self.stop_changed,None)
-        self.tbl_keyframes_right.attach(self.spin_kf_stop,1,2,1,2)
+        self.tbl_keyframes_right.attach(self.spin_kf_stop,1,1,1,1)
 
         self.lbl_int_type=Gtk.Label(label="Interpolation type:")
-        self.tbl_keyframes_right.attach(self.lbl_int_type,0,1,2,3)
+        self.tbl_keyframes_right.attach(self.lbl_int_type,0,2,1,1)
 
         self.cmb_interpolation_type=Gtk.ComboBoxText() #Gtk.ComboBox()
         self.cmb_interpolation_type.append_text("Linear")
@@ -598,20 +602,23 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.cmb_interpolation_type.append_text("Cosine")
         self.cmb_interpolation_type.set_active(0)
         self.cmb_interpolation_type.connect("changed",self.interpolation_type_changed,None)
-        self.tbl_keyframes_right.attach(self.cmb_interpolation_type,1,2,2,3)
+        self.tbl_keyframes_right.attach(self.cmb_interpolation_type,1,2,1,1)
 
         self.btn_adv_opt=Gtk.Button(label="Advanced options")
         self.btn_adv_opt.connect("clicked",self.adv_opt_clicked,None)
-        self.tbl_keyframes_right.attach(self.btn_adv_opt,0,2,3,4)
+        self.tbl_keyframes_right.attach(self.btn_adv_opt,0,3,2,1)
 
-        self.current_kf.add(self.tbl_keyframes_right) #,False,False,10)
+        self.current_kf.add(self.tbl_keyframes_right)
         # -------------------------------------------------------------------
         # ----------------------output box-----------------------------------
         self.frm_output = Gtk.Frame.new("Output options")
         self.frm_output.set_border_width(10)
 
-        self.box_output_main=Gtk.VBox(homogeneous=True,spacing=10)
-        self.box_output_file=Gtk.HBox(homogeneous=False,spacing=10)
+        self.box_output_main = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
+            homogeneous=True, spacing=10)
+        self.box_output_main.set_border_width(10)
+        self.box_output_file = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL,
+            homogeneous=False, spacing=10)
 
         self.lbl_temp_avi=Gtk.Label(label="Resulting video file:")
         self.box_output_file.pack_start(self.lbl_temp_avi,False,False,10)
@@ -630,7 +637,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.lbl_res=Gtk.Label(label="Resolution:")
         self.box_output_res.pack_start(self.lbl_res,False,False,10)
 
-        adj_width = Gtk.Adjustment(640,320,2048,10,100,0)
+        adj_width = Gtk.Adjustment.new(640,320,2048,10,100,0)
         self.spin_width = Gtk.SpinButton()
         self.spin_width.set_adjustment(adj_width)
         self.spin_width.connect("output",self.output_width_changed,None)
@@ -639,7 +646,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.lbl_x=Gtk.Label(label="x")
         self.box_output_res.pack_start(self.lbl_x,False,False,10)
 
-        adj_height=Gtk.Adjustment(480,240,1536,10,100,0)
+        adj_height=Gtk.Adjustment.new(480,240,1536,10,100,0)
         self.spin_height = Gtk.SpinButton()
         self.spin_height.set_adjustment(adj_height)
         self.spin_height.connect("output",self.output_height_changed,None)
@@ -652,7 +659,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         self.lbl_framerate=Gtk.Label(label="Frame rate:")
         self.box_output_framerate.pack_start(self.lbl_framerate,False,False,10)
 
-        adj_framerate = Gtk.Adjustment(25,5,100,1,5,0)
+        adj_framerate = Gtk.Adjustment.new(25,5,100,1,5,0)
         self.spin_framerate = Gtk.SpinButton()
         self.spin_framerate.set_adjustment(adj_framerate)
         self.spin_framerate.connect("output",self.output_framerate_changed,None)

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -20,9 +20,6 @@ from fract4d import animation, fractconfig
 
 from . import PNGGen,AVIGen,DlgAdvOpt,director_prefs
 
-def show(parent,alt_parent, f,dialog_mode,conf_file=""):
-    DirectorDialog.show(parent,alt_parent, f,dialog_mode,conf_file)
-
 class UserCancelledError(Exception):
 	pass
 
@@ -33,11 +30,6 @@ class SanityCheckError(Exception):
 
 class DirectorDialog(dialog.T,hig.MessagePopper):
     RESPONSE_RENDER=1
-    def show(parent, alt_parent, f,dialog_mode,conf_file):
-        dialog.T.reveal(DirectorDialog, dialog_mode,
-                        parent, alt_parent, f,conf_file)
-
-    show = staticmethod(show)
 
     def check_for_keyframe_clash(self,keyframe,fct_dir):
         keydir=os.path.dirname(keyframe)
@@ -445,22 +437,19 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         res=dlg.show()
 
     #creating window...
-    def __init__(self, main_window, f,conf_file):
+    def __init__(self, main_window, f, conf_file=""):
         dialog.T.__init__(
             self,
             _("Director"),
             main_window,
             (_("_Render"), DirectorDialog.RESPONSE_RENDER,
-             Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True)
+             Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
+        )
 
         hig.MessagePopper.__init__(self)
         self.animation=animation.T(f.compiler)
         self.f=f
         self.compiler = f.compiler
-        self.realize()
-
-        self.main_window = main_window
 
         #main VBox
         self.box_main=Gtk.VBox(False,0)
@@ -706,6 +695,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
 
         #--------------showing all-------------------------------
         self.vbox.add(self.box_main)
+        self.vbox.show_all()
         self.controls = self.vbox
         if conf_file!="":
             self.load_configuration(conf_file)

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -221,9 +221,7 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
             self.check_sanity()
         except SanityCheckError as exn:
             self.show_error(_("Cannot Generate Animation"), str(exn))
-            return
-        except UserCancelledError:
-            return
+            raise
 
         png_gen=PNGGen.PNGGeneration(self.animation, self.compiler, self)
         res=png_gen.show()
@@ -711,7 +709,11 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
             self.hide()
         elif id == DirectorDialog.RESPONSE_RENDER:
             self.animation.set_avi_file(self.txt_temp_avi.get_text())
-            self.generate(self.converterpath is not None)
+            try:
+                self.generate(self.converterpath is not None)
+            except (SanityCheckError, UserCancelledError):
+                # prevent dialog closing if being run
+                GObject.signal_stop_emission_by_name(self, "response")
 
     def main(self):
         Gtk.main()

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -510,14 +510,12 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         #--------------Keyframes box-----------------------------------
         self.frm_kf = Gtk.Frame.new("Keyframes")
         self.frm_kf.set_border_width(10)
-        self.hbox_kfs=Gtk.HBox(homogeneous=False,spacing=0)
-        self.tbl_keyframes_left=Gtk.Table(n_rows=2,n_columns=2,homogeneous=False)
-        self.tbl_keyframes_left.set_row_spacings(10)
-        self.tbl_keyframes_left.set_col_spacings(10)
-        self.tbl_keyframes_left.set_border_width(10)
-
+        vbox_kfs = Gtk.Box.new(Gtk.Orientation.VERTICAL, 8)
+        button_box_kfs = Gtk.ButtonBox()
+        button_box_kfs.set_layout(Gtk.ButtonBoxStyle.SPREAD)
         self.sw=Gtk.ScrolledWindow()
         self.sw.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        self.sw.set_size_request(-1, 100)
 #        filenames=Gtk.ListStore(GObject.TYPE_STRING,
 #            GObject.TYPE_STRING)
 #        self.tv_keyframes=Gtk.TreeView(filenames)
@@ -546,23 +544,25 @@ class DirectorDialog(dialog.T,hig.MessagePopper):
         column = Gtk.TreeViewColumn('Interpolation type', Gtk.CellRendererText(),text=3)
         self.tv_keyframes.append_column(column)
 
-        self.sw.add_with_viewport(self.tv_keyframes)
+        self.sw.add(self.tv_keyframes)
         self.tv_keyframes.get_selection().connect("changed",self.selection_changed,None)
         self.tv_keyframes.get_selection().set_select_function(self.before_selection,None)
         self.current_select=-1
-        self.tbl_keyframes_left.attach(self.sw,0,2,0,1)
 
         self.btn_add_keyframe=Gtk.Button.new_from_stock(Gtk.STOCK_ADD)
         #self.btn_add_keyframe.connect("clicked",self.add_keyframe_clicked,None)
         self.btn_add_keyframe.connect_object("event",self.add_keyframe_clicked,self.popup_menu)
-        self.tbl_keyframes_left.attach(self.btn_add_keyframe,0,1,1,2,0,0)
 
         self.btn_remove_keyframe=Gtk.Button.new_from_stock(Gtk.STOCK_REMOVE)
         self.btn_remove_keyframe.connect("clicked",self.remove_keyframe_clicked,None)
-        self.tbl_keyframes_left.attach(self.btn_remove_keyframe,1,2,1,2,0,0)
-        self.hbox_kfs.pack_start(self.tbl_keyframes_left,True,True,10)
 
-        self.frm_kf.add(self.hbox_kfs)
+        button_box_kfs.pack_start(self.btn_add_keyframe, True, True, 0)
+        button_box_kfs.pack_start(self.btn_remove_keyframe, True, True, 0)
+
+        vbox_kfs.pack_start(self.sw, True, True, 0)
+        vbox_kfs.pack_start(button_box_kfs, True, True, 10)
+        
+        self.frm_kf.add(vbox_kfs)
         self.box_main.pack_start(self.frm_kf,True,True,0)
 
         # current keyframe box

--- a/fract4dgui/director_prefs.py
+++ b/fract4dgui/director_prefs.py
@@ -1,127 +1,124 @@
-from gi.repository import Gtk
-from gi.repository import GObject
 import os
 
-from fract4d import animation
+from gi.repository import Gtk
 
 class DirectorPrefs:
+    # wrapper to show dialog for selecting folder
+    # returns selected folder or empty string
+    def get_folder(self):
+        temp_folder = ""
+        dialog = Gtk.FileChooserDialog("Choose directory...",None,Gtk.FileChooserAction.SELECT_FOLDER,
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
+        dialog.set_default_response(Gtk.ResponseType.OK)
+        response = dialog.run()
+        if response == Gtk.ResponseType.OK:
+            temp_folder = dialog.get_filename()
+        dialog.destroy()
+        return temp_folder
 
-	#wrapper to show dialog for selecting folder
-	#returns selected folder or empty string
-	def get_folder(self):
-		temp_folder=""
-		dialog = Gtk.FileChooserDialog("Choose directory...",None,Gtk.FileChooserAction.SELECT_FOLDER,
-			(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
-		dialog.set_default_response(Gtk.ResponseType.OK)
-		response = dialog.run()
-		if response == Gtk.ResponseType.OK:
-			temp_folder=dialog.get_filename()
-		dialog.destroy()
-		return temp_folder
+    def create_fct_toggled(self,widget,data=None):
+        self.btn_temp_fct.set_sensitive(self.chk_create_fct.get_active())
+        self.txt_temp_fct.set_sensitive(self.chk_create_fct.get_active())
 
-	def create_fct_toggled(self,widget,data=None):
-		self.btn_temp_fct.set_sensitive(self.chk_create_fct.get_active())
-		self.txt_temp_fct.set_sensitive(self.chk_create_fct.get_active())
+    def temp_fct_clicked(self,widget, data=None):
+        fold = self.get_folder()
+        if fold != "":
+            self.txt_temp_fct.set_text(fold)
 
-	def temp_fct_clicked(self,widget, data=None):
-		fold=self.get_folder()
-		if fold!="":
-			self.txt_temp_fct.set_text(fold)
+    def temp_png_clicked(self,widget, data=None):
+        fold = self.get_folder()
+        if fold != "":
+            self.txt_temp_png.set_text(fold)
 
-	def temp_png_clicked(self,widget, data=None):
-		fold=self.get_folder()
-		if fold!="":
-			self.txt_temp_png.set_text(fold)
+    def __init__(self,animation,parent):
+        self.dialog = Gtk.Dialog("Director preferences...",parent,
+                      Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+                      (Gtk.STOCK_OK,Gtk.ResponseType.OK,Gtk.STOCK_CANCEL,Gtk.ResponseType.CANCEL))
 
-	def __init__(self,animation,parent):
-		self.dialog=Gtk.Dialog("Director preferences...",parent,
-					Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
-					(Gtk.STOCK_OK,Gtk.ResponseType.OK,Gtk.STOCK_CANCEL,Gtk.ResponseType.CANCEL))
+        self.animation = animation
+        # -----------Temporary directories---------------------
+        #self.frm_dirs=Gtk.Frame("Temporary directories selection")
+        #self.frm_dirs.set_border_width(10)
+        self.tbl_dirs = Gtk.Table(n_rows=3,n_columns=3,homogeneous=False)
+        self.tbl_dirs.set_row_spacings(10)
+        self.tbl_dirs.set_col_spacings(10)
+        self.tbl_dirs.set_border_width(10)
 
-		self.animation=animation
-		#-----------Temporary directories---------------------
-		#self.frm_dirs=Gtk.Frame("Temporary directories selection")
-		#self.frm_dirs.set_border_width(10)
-		self.tbl_dirs=Gtk.Table(n_rows=3,n_columns=3,homogeneous=False)
-		self.tbl_dirs.set_row_spacings(10)
-		self.tbl_dirs.set_col_spacings(10)
-		self.tbl_dirs.set_border_width(10)
+        self.lbl_temp_fct = Gtk.Label(label="Temporary directory for .fct files:")
+        self.tbl_dirs.attach(self.lbl_temp_fct,0,1,1,2)
 
-		self.lbl_temp_fct=Gtk.Label(label="Temporary directory for .fct files:")
-		self.tbl_dirs.attach(self.lbl_temp_fct,0,1,1,2)
+        self.txt_temp_fct = Gtk.Entry()
+        self.txt_temp_fct.set_text(self.animation.get_fct_dir())
+        self.txt_temp_fct.set_sensitive(False)
+        self.tbl_dirs.attach(self.txt_temp_fct,1,2,1,2)
 
-		self.txt_temp_fct = Gtk.Entry()
-		self.txt_temp_fct.set_text(self.animation.get_fct_dir())
-		self.txt_temp_fct.set_sensitive(False)
-		self.tbl_dirs.attach(self.txt_temp_fct,1,2,1,2)
+        self.btn_temp_fct = Gtk.Button(label="Browse")
+        self.btn_temp_fct.connect("clicked",self.temp_fct_clicked,None)
+        self.btn_temp_fct.set_sensitive(False)
+        self.tbl_dirs.attach(self.btn_temp_fct,2,3,1,2)
 
-		self.btn_temp_fct=Gtk.Button(label="Browse")
-		self.btn_temp_fct.connect("clicked",self.temp_fct_clicked,None)
-		self.btn_temp_fct.set_sensitive(False)
-		self.tbl_dirs.attach(self.btn_temp_fct,2,3,1,2)
+        # this check box goes after (even if it's above above widgets because
+        # we connect and change its state here and it change those buttons, so they wouldn't exist
+        self.chk_create_fct = Gtk.CheckButton(label="Create temporary .fct files")
+        self.chk_create_fct.connect("toggled",self.create_fct_toggled,None)
+        self.chk_create_fct.set_active(self.animation.get_fct_enabled())
+        self.tbl_dirs.attach(self.chk_create_fct,0,1,0,1)
 
-		#this check box goes after (even if it's above above widgets because
-		#we connect and change its state here and it change those buttons, so they wouldn't exist
-		self.chk_create_fct=Gtk.CheckButton(label="Create temporary .fct files")
-		self.chk_create_fct.connect("toggled",self.create_fct_toggled,None)
-		self.chk_create_fct.set_active(self.animation.get_fct_enabled())
-		self.tbl_dirs.attach(self.chk_create_fct,0,1,0,1)
+        self.lbl_temp_png = Gtk.Label(label="Temporary directory for .png files:")
+        self.tbl_dirs.attach(self.lbl_temp_png,0,1,2,3)
 
-		self.lbl_temp_png=Gtk.Label(label="Temporary directory for .png files:")
-		self.tbl_dirs.attach(self.lbl_temp_png,0,1,2,3)
+        self.txt_temp_png = Gtk.Entry()
+        self.txt_temp_png.set_text(self.animation.get_png_dir())
+        self.tbl_dirs.attach(self.txt_temp_png,1,2,2,3)
 
-		self.txt_temp_png = Gtk.Entry()
-		self.txt_temp_png.set_text(self.animation.get_png_dir())
-		self.tbl_dirs.attach(self.txt_temp_png,1,2,2,3)
+        self.btn_temp_png = Gtk.Button(label="Browse")
+        self.btn_temp_png.connect("clicked",self.temp_png_clicked,None)
+        self.tbl_dirs.attach(self.btn_temp_png,2,3,2,3)
 
-		self.btn_temp_png=Gtk.Button(label="Browse")
-		self.btn_temp_png.connect("clicked",self.temp_png_clicked,None)
-		self.tbl_dirs.attach(self.btn_temp_png,2,3,2,3)
+        #self.frm_dirs.add(self.tbl_dirs)
+        self.dialog.vbox.pack_start(self.tbl_dirs,False,False,0)
+        #self.dialog.vbox.pack_start(self.tbl_main,True,True,0)
 
-		#self.frm_dirs.add(self.tbl_dirs)
-		self.dialog.vbox.pack_start(self.tbl_dirs,False,False,0)
-		#self.dialog.vbox.pack_start(self.tbl_main,True,True,0)
+    # checking is txt fields valid dirs
+    def check_fields(self):
+        if self.chk_create_fct.get_active():
+            # checking fct dir
+            if not os.path.isdir(self.txt_temp_fct.get_text()):
+                error_dlg = Gtk.MessageDialog(None,Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+                                            Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,
+                                            "Directory for temporary .fct files is not directory")
+                error_dlg.run()
+                error_dlg.destroy()
+                return False
+        if not os.path.isdir(self.txt_temp_png.get_text()):
+            error_dlg = Gtk.MessageDialog(None,Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+                                        Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,
+                                        "Directory for temporary .png files is not directory")
+            error_dlg.run()
+            error_dlg.destroy()
+            return False
+        return True
 
-	#checking is txt fields valid dirs
-	def check_fields(self):
-		if self.chk_create_fct.get_active():
-			#checking fct dir
-			if not os.path.isdir(self.txt_temp_fct.get_text()):
-				error_dlg = Gtk.MessageDialog(None,Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
-											Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,
-											"Directory for temporary .fct files is not directory")
-				error_dlg.run()
-				error_dlg.destroy()
-				return False
-		if not os.path.isdir(self.txt_temp_png.get_text()):
-			error_dlg = Gtk.MessageDialog(None,Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
-										Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,
-										"Directory for temporary .png files is not directory")
-			error_dlg.run()
-			error_dlg.destroy()
-			return False
-		return True
+    def show(self):
+        self.dialog.show_all()
+        # nasty, nasty hack to keep dialog running while either it is canceled or
+        # valid dirs are entered
+        is_ok = False
+        write = False
+        while is_ok is False:
+            response = self.dialog.run()
+            if response == Gtk.ResponseType.OK:
+                    is_ok = self.check_fields()
+                    if is_ok:
+                        write = True
+            else:
+                is_ok = True
 
-	def show(self):
-		self.dialog.show_all()
-		#nasty, nasty hack to keep dialog running while either it is canceled or
-		#valid dirs are entered
-		is_ok=False
-		write=False
-		while is_ok==False:
-			response = self.dialog.run()
-			if response == Gtk.ResponseType.OK:
-					is_ok=self.check_fields()
-					if is_ok:
-						write=True
-			else:
-				is_ok=True
+        if write:
+            self.animation.set_fct_enabled(self.chk_create_fct.get_active())
+            if self.chk_create_fct.get_active():
+                self.animation.set_fct_dir(self.txt_temp_fct.get_text())
+            self.animation.set_png_dir(self.txt_temp_png.get_text())
 
-		if write:
-			self.animation.set_fct_enabled(self.chk_create_fct.get_active())
-			if self.chk_create_fct.get_active():
-				self.animation.set_fct_dir(self.txt_temp_fct.get_text())
-			self.animation.set_png_dir(self.txt_temp_png.get_text())
-
-		self.dialog.destroy()
-		return
+        self.dialog.destroy()
+        return

--- a/fract4dgui/director_prefs.py
+++ b/fract4dgui/director_prefs.py
@@ -33,8 +33,8 @@ class DirectorPrefs:
 		if fold!="":
 			self.txt_temp_png.set_text(fold)
 
-	def __init__(self,animation):
-		self.dialog=Gtk.Dialog("Director preferences...",None,
+	def __init__(self,animation,parent):
+		self.dialog=Gtk.Dialog("Director preferences...",parent,
 					Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
 					(Gtk.STOCK_OK,Gtk.ResponseType.OK,Gtk.STOCK_CANCEL,Gtk.ResponseType.CANCEL))
 

--- a/fract4dgui/fourway.py
+++ b/fract4dgui/fourway.py
@@ -12,12 +12,12 @@ class T(Gtk.DrawingArea):
         None, (GObject.TYPE_INT, GObject.TYPE_INT))
         }
 
-    def __init__(self,text):        
+    def __init__(self,text):
         self.button = 0
         self.radius = 0
         self.last_x = 0
-        self.last_y = 0        
-        self.text=text
+        self.last_y = 0
+        self.text = text
         Gtk.DrawingArea.__init__(self)
 
         self.set_size_request(53,53)
@@ -49,11 +49,10 @@ class T(Gtk.DrawingArea):
     def onMotionNotify(self,widget,event):
         if not self.notice_mouse:
             return
-        dummy = widget.get_pointer()
         self.update_from_mouse(event.x, event.y)
 
     def onButtonRelease(self,widget,event):
-        if event.button==1:
+        if event.button == 1:
             self.notice_mouse = False
             (xc,yc) = (widget.get_allocated_width()//2, widget.get_allocated_height()//2)
             dx = xc - self.last_x
@@ -74,12 +73,10 @@ class T(Gtk.DrawingArea):
     def redraw_rect(self, widget, cairo_ctx):
         style_ctx = widget.get_style_context()
         (w,h) = (widget.get_allocated_width(), widget.get_allocated_height())
-        Gtk.render_background(style_ctx,
-            cairo_ctx, 0, 0, w-1, h-1)
+        Gtk.render_background(style_ctx, cairo_ctx, 0, 0, w-1, h-1)
 
         xc = w//2
         yc = h//2
-        radius = min(w,h)//2 -1
 
         # Consider using gtk_render_arrow
         def triangle(points):
@@ -93,7 +90,7 @@ class T(Gtk.DrawingArea):
         th = 8
         tw = 6
 
-        # Triangle pointing left        
+        # Triangle pointing left
         points = [
             (1, yc),
             (1+th, yc-tw),
@@ -102,23 +99,23 @@ class T(Gtk.DrawingArea):
 
         # pointing right
         points = [
-            (w -2, yc),
-            (w -2 -th, yc-tw),
-            (w -2 -th, yc+tw)]
+            (w-2, yc),
+            (w-2-th, yc-tw),
+            (w-2-th, yc+tw)]
         triangle(points)
 
         # pointing up
         points = [
             (xc, 1),
-            (xc - tw, th),
-            (xc + tw, th)]
+            (xc-tw, th),
+            (xc+tw, th)]
         triangle(points)
         
         # pointing down
         points = [
-            (xc, h - 2),
-            (xc - tw, h - 2 - th),
-            (xc + tw, h - 2 - th)]
+            (xc, h-2),
+            (xc-tw, h-2-th),
+            (xc+tw, h-2-th)]
         triangle(points)
 
         pango_ctx = widget.get_pango_context()
@@ -135,7 +132,7 @@ class T(Gtk.DrawingArea):
             
             (text_width, text_height) = layout.get_pixel_size()
             # truncate text if it's too long
-            if text_width < (w - th *2) or len(drawtext) < 3:
+            if text_width < (w-th*2) or len(drawtext) < 3:
                 break
             drawtext = drawtext[:-1]
 

--- a/fract4dgui/fourway.py
+++ b/fract4dgui/fourway.py
@@ -1,12 +1,8 @@
-# Sort of a widget which controls 2 linear dimensions of the fractal
-# I say sort of, because this doesn't actually inherit from Gtk.Widget,
-# so it's not really a widget. This is because if I attempt to do that
-# pygtk crashes. Hence I delegate to a member which actually is a widget
-# with some stuff drawn on it - basically an ungodly hack.
+# A widget which controls 2 linear dimensions of the fractal
 
 from gi.repository import Gtk, Gdk, GObject, Pango
 
-class T(GObject.GObject):
+class T(Gtk.DrawingArea):
     __gsignals__ = {
         'value-changed' : (
         (GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.NO_RECURSE),
@@ -22,12 +18,11 @@ class T(GObject.GObject):
         self.last_x = 0
         self.last_y = 0        
         self.text=text
-        GObject.GObject.__init__(self)
-        
-        self.widget = Gtk.DrawingArea()
-        self.widget.set_size_request(53,53)
+        Gtk.DrawingArea.__init__(self)
 
-        self.widget.set_events(
+        self.set_size_request(53,53)
+
+        self.set_events(
             Gdk.EventMask.BUTTON_RELEASE_MASK |
             Gdk.EventMask.BUTTON1_MOTION_MASK |
             Gdk.EventMask.POINTER_MOTION_HINT_MASK |
@@ -38,10 +33,10 @@ class T(GObject.GObject):
             )
 
         self.notice_mouse = False
-        self.widget.connect('motion_notify_event', self.onMotionNotify)
-        self.widget.connect('button_release_event', self.onButtonRelease)
-        self.widget.connect('button_press_event', self.onButtonPress)
-        self.widget.connect('draw',self.onDraw)
+        self.connect('motion_notify_event', self.onMotionNotify)
+        self.connect('button_release_event', self.onButtonRelease)
+        self.connect('button_press_event', self.onButtonPress)
+        self.connect('draw',self.onDraw)
         
     def update_from_mouse(self,x,y):
         dx = self.last_x - x
@@ -73,12 +68,6 @@ class T(GObject.GObject):
             self.last_y = widget.get_allocated_height()/2
             self.update_from_mouse(event.x, event.y)
 
-    def __del__(self):
-        #This is truly weird. If I don't have this method, when you use
-        # one fourway widget, it fucks up the other. Having this fixes it.
-        # *even though it doesn't do anything*. Disturbing.
-        pass
-        
     def onDraw(self, widget, cairo_ctx):
         self.redraw_rect(widget, cairo_ctx)
 
@@ -156,7 +145,3 @@ class T(GObject.GObject):
             xc - text_width//2,
             yc - text_height//2,
             layout)
-
-        
-# explain our existence to GTK's object system
-GObject.type_register(T)

--- a/fract4dgui/gtkfractal.py
+++ b/fract4dgui/gtkfractal.py
@@ -690,7 +690,7 @@ class T(Hidden):
         name = self.param_display_name(name,param)
         fway = fourway.T(name)
         tip = self.param_tip(name,param)
-        fway.widget.set_tooltip_text(tip)
+        fway.set_tooltip_text(tip)
         
         fway.connect('value-changed',self.fourway_released, order, form)
 
@@ -699,7 +699,7 @@ class T(Hidden):
                 'value-slightly-changed',
                 self.parent.on_drag_param_fourway, order, param_type)
         
-        table.attach(fway.widget,0,1,i,i+2, Gtk.AttachOptions.EXPAND|Gtk.AttachOptions.FILL,0, 0,0)
+        table.attach(fway,0,1,i,i+2, Gtk.AttachOptions.EXPAND|Gtk.AttachOptions.FILL,0, 0,0)
 
     def fourway_released(self,widget,x,y,order,form):
         form.nudge_param(order, x,y)

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -1002,12 +1002,12 @@ class MainWindow:
         my_angle.axis = axis
 
         self.toolbar.add_widget(
-            my_angle.widget,
+            my_angle,
             tip,
             tip)
 
         if is4dsensitive:
-            self.four_d_sensitives.append(my_angle.widget)
+            self.four_d_sensitives.append(my_angle)
         
     def update_angle_widget(self,f,widget):
         widget.set_value(f.get_param(widget.axis))
@@ -1074,7 +1074,7 @@ class MainWindow:
     def add_fourway(self, name, tip, axis, is4dsensitive):
         my_fourway = fourway.T(name)
         self.toolbar.add_widget(
-            my_fourway.widget,
+            my_fourway,
             tip,
             None)
 
@@ -1084,7 +1084,7 @@ class MainWindow:
         my_fourway.connect('value-changed', self.on_release_fourway)
 
         if is4dsensitive:
-            self.four_d_sensitives.append(my_fourway.widget)
+            self.four_d_sensitives.append(my_fourway)
 
     def update_recent_files(self, file):
         self.recent_files = preferences.userPrefs.update_list("recent_files",file,4)

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -120,7 +120,9 @@ class MainWindow:
         self.saveas_fs = None
         self.saveimage_fs = None
         self.hires_image_fs = None
-        self.open_fs = None        
+        self.open_fs = None
+        
+        self.renderQueue = renderqueue.T()
 
         self.update_subfract_visibility(False)
         self.populate_warpmenu(self.f)
@@ -138,6 +140,7 @@ class MainWindow:
         self.f.set_saved(True)
 
         self.painterDialog = painter.PainterDialog(self.window, self.f)
+        self.renderqueueDialog = renderqueue.QueueDialog(self.window, self.f, self.renderQueue)
 
     def create_rtd_widgets(self):
         table = Gtk.Table(n_rows=2,n_columns=3,homogeneous=False)
@@ -731,9 +734,9 @@ class MainWindow:
         self.painterDialog.show()
 
     def add_to_queue(self,name,w,h):
-        renderqueue.show(self.window,None,self.f)
-        renderqueue.instance.add(self.f.f,name,w,h)
-        renderqueue.instance.start()
+        self.renderqueueDialog.show()
+        self.renderQueue.add(self.f.f,name,w,h)
+        self.renderQueue.start()
         
     def toggle_explorer(self, action):
         """Enter (or leave) Explorer mode."""
@@ -1398,7 +1401,7 @@ class MainWindow:
             elif response == hig.SaveConfirmationAlert.NOSAVE:
                 break
 
-        while not renderqueue.instance.empty():
+        while not self.renderQueue.empty():
             d = hig.ConfirmationAlert(
                 primary=_("Render queue still processing."),
                 secondary=_("If you proceed, queued images will not be saved"),

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -103,16 +103,24 @@ class MainWindow:
             
         self.create_ui()
         self.create_toolbar()
-        self.create_fractal(self.f)
+        self.panes = Gtk.Paned.new(Gtk.Orientation.HORIZONTAL)
+        self.vbox.add(self.panes)
         self.create_status_bar()
+
+        self.create_fractal(self.f)
+        self.panes.pack1(self.swindow, resize=True, shrink=True)
+
+        # show everything apart from the settings pane
+        self.window.show_all()
+
+        self.settingsPane = settings.SettingsPane(self, self.f)
+        self.panes.pack2(self.settingsPane, resize=False, shrink=False)
 
         # create these properly later to avoid 'end from FAM server connection' messages
         self.saveas_fs = None
         self.saveimage_fs = None
         self.hires_image_fs = None
         self.open_fs = None        
-        
-        self.window.show_all()
 
         self.update_subfract_visibility(False)
         self.populate_warpmenu(self.f)
@@ -383,12 +391,6 @@ class MainWindow:
         f.connect('progress_changed', self.progress_changed)
         f.connect('status_changed',self.status_changed)
         f.connect('stats-changed', self.stats_changed)
-
-        hbox = Gtk.HBox()
-        hbox.pack_start(self.swindow, True, True, 0)
-        self.control_box = Gtk.VBox()
-        hbox.pack_start(self.control_box, False, False, 0)
-        self.vbox.pack_start(hbox, True, True, 0)
 
     def draw(self):        
         nt = preferences.userPrefs.getint("general","threads") 
@@ -1216,7 +1218,7 @@ class MainWindow:
         
     def settings(self,*args):
         """Show fractal settings controls."""
-        settings.show_settings(self.window, self.control_box, self.f, False)
+        self.settingsPane.show()
         
     def preferences(self,*args):
         """Change current preferences."""

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -99,8 +99,6 @@ class MainWindow:
             'image-preferences-changed',
             self.on_prefs_changed)
 
-        browser.update(self.f.forms[0].funcFile, self.f.forms[0].funcName)
-            
         self.create_ui()
         self.create_toolbar()
         self.panes = Gtk.Paned.new(Gtk.Orientation.HORIZONTAL)
@@ -724,7 +722,9 @@ class MainWindow:
         
     def browser(self,*args):
         """Display formula browser."""
-        browser.show(self.window,self.f)
+        dialog = browser.BrowserDialog(self, self.f)
+        dialog.run()
+        dialog.destroy()
 
     def randomize_colors(self,*args):
         """Create a new random color scheme."""
@@ -1366,7 +1366,6 @@ class MainWindow:
                 fh.close()
             self.update_recent_files(file)
             self.set_filename(file)
-            browser.update(self.f.forms[0].funcFile, self.f.forms[0].funcName)
             return True
         except Exception as err:
             self.show_error_message(_("Error opening %s") % file,err)
@@ -1375,10 +1374,10 @@ class MainWindow:
     def load_formula(self,file):
         try:
             self.compiler.load_formula_file(file)
-            type = browser.guess_type(file)
-            browser.set_type(type)
-            browser.update(file)
-            browser.show(self.window, self.f, type)
+            dialog = browser.BrowserDialog(self, self.f)
+            dialog.load_file(file)
+            dialog.run()
+            dialog.destroy()
 
             return True
         except Exception as err:

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -66,7 +66,8 @@ class MainWindow:
 
         # create fractal compiler and load standard formula and
         # coloring algorithm files
-        self.compiler = fc.instance
+        self.compiler = fc.Compiler()
+        self.compiler.update_from_prefs(fractconfig.instance)
 
         for path in extra_paths:
             self.compiler.add_func_path(path)

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -718,7 +718,9 @@ class MainWindow:
 
     def director(self,*args):
         """Display the Director (animation) window."""
-        director.show(self.window,self.control_box, self.f, True)
+        dialog = director.DirectorDialog(self.window, self.f)
+        dialog.run()
+        dialog.destroy()
         
     def browser(self,*args):
         """Display formula browser."""

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -849,7 +849,7 @@ class MainWindow:
         
         self.add_fourway(
             _("pan"),
-            _("Pan around the image"), 0, True)
+            _("Pan around the image"), 0, False)
         self.add_fourway(
             _("warp"),
             _("Mutate the image by moving along the other 2 axes"), 2, True)

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -137,6 +137,8 @@ class MainWindow:
 
         self.f.set_saved(True)
 
+        self.painterDialog = painter.PainterDialog(self.window, self.f)
+
     def create_rtd_widgets(self):
         table = Gtk.Table(n_rows=2,n_columns=3,homogeneous=False)
         table.width = width = Gtk.Entry()
@@ -726,7 +728,7 @@ class MainWindow:
         self.f.make_random_colors(8)
 
     def painter(self,*args):
-        painter.show(self.window,self.f)
+        self.painterDialog.show()
 
     def add_to_queue(self,name,w,h):
         renderqueue.show(self.window,None,self.f)

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -1222,7 +1222,9 @@ class MainWindow:
         
     def preferences(self,*args):
         """Change current preferences."""
-        preferences.show_preferences(self.window, self.f)
+        dialog = preferences.PrefsDialog(self.window, self.f)
+        dialog.run()
+        dialog.destroy()
         
     def undo(self,*args):
         """Undo the last operation."""
@@ -1272,7 +1274,9 @@ class MainWindow:
 
     def autozoom(self,*args):
         """Display AutoZoom dialog."""
-        autozoom.show_autozoom(self.window, self.f)
+        dialog = autozoom.AutozoomDialog(self.window, self.f)
+        dialog.run()
+        dialog.destroy()
 
     def contents(self,*args):
         """Show help file contents page."""

--- a/fract4dgui/painter.py
+++ b/fract4dgui/painter.py
@@ -3,8 +3,6 @@
 from gi.repository import Gtk
 
 from . import dialog
-from . import browser
-from . import utils
 
 class PainterDialog(dialog.T):
     def __init__(self,main_window,f):
@@ -17,7 +15,7 @@ class PainterDialog(dialog.T):
         )
 
         self.f = f
-        self.paint_toggle = Gtk.ToggleButton(_("Painting"))
+        self.paint_toggle = Gtk.ToggleButton.new_with_label(_("Painting"))
         self.paint_toggle.set_active(True)
         self.paint_toggle.connect('toggled',self.onChangePaintMode)
         self.csel = Gtk.ColorSelection()
@@ -34,4 +32,4 @@ class PainterDialog(dialog.T):
                id == Gtk.ResponseType.NONE or \
                id == Gtk.ResponseType.DELETE_EVENT:
             self.hide()
-            self.f.set_paint_mode(False,None) 
+            self.f.set_paint_mode(False,None)

--- a/fract4dgui/painter.py
+++ b/fract4dgui/painter.py
@@ -6,24 +6,16 @@ from . import dialog
 from . import browser
 from . import utils
 
-def show(parent,f):
-    PainterDialog.show(parent,f)
-
 class PainterDialog(dialog.T):
-    def show(parent, f):
-        dialog.T.reveal(PainterDialog, True, parent, None, f)
-
-    show = staticmethod(show)
-    
     def __init__(self,main_window,f):
         dialog.T.__init__(
             self,
             _("Painter"),
             main_window,
             (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True)
+            modal=False
+        )
 
-        self.main_window = main_window
         self.f = f
         self.paint_toggle = Gtk.ToggleButton(_("Painting"))
         self.paint_toggle.set_active(True)

--- a/fract4dgui/preferences.py
+++ b/fract4dgui/preferences.py
@@ -67,10 +67,8 @@ class Preferences(GObject.GObject):
 GObject.type_register(Preferences)
 
 userPrefs = Preferences(fractconfig.instance)
-    
-def show_preferences(parent,f):
-    PrefsDialog.show(parent,f)
-    
+
+
 class PrefsDialog(dialog.T):
     def __init__(self,main_window,f):
         global userPrefs
@@ -78,8 +76,8 @@ class PrefsDialog(dialog.T):
             self,
             _("Gnofract 4D Preferences"),
             main_window,
-            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True)
+            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
+        )
 
         self.dirchooser = utils.get_directory_chooser(
             _("Select a Formula Directory"),
@@ -94,13 +92,9 @@ class PrefsDialog(dialog.T):
         self.create_compiler_options_page()
         self.create_general_page()
         self.create_helper_options_page()
+        self.vbox.show_all()
         
         self.set_size_request(500,-1)
-
-    def show(parent, f):
-        dialog.T.reveal(PrefsDialog, True, parent, None, f)
-
-    show = staticmethod(show)
 
     def show_error(self,message):
         d = Gtk.MessageDialog(self, Gtk.DialogFlags.MODAL,

--- a/fract4dgui/preferences.py
+++ b/fract4dgui/preferences.py
@@ -1,14 +1,8 @@
 # GUI for user settings
 
-import os
-import sys
+from gi.repository import Gtk, GObject
 
-from gi.repository import Gtk
-from gi.repository import GObject
-
-from . import dialog
-from . import utils
-
+from . import dialog, utils
 from fract4d import fractconfig
 
 class Preferences(GObject.GObject):
@@ -119,7 +113,7 @@ class PrefsDialog(dialog.T):
                 except ValueError:
                     Gtk.idle_add(
                         self.show_error,
-                        "Invalid value for width: '%s'. Must be an integer" % \
+                        "Invalid value for width: '%s'. Must be an integer" %
                         entry.get_text())
                     return False
 
@@ -151,7 +145,7 @@ class PrefsDialog(dialog.T):
                 except ValueError:
                     utils.idle_add(
                         self.show_error,
-                        "Invalid value for height: '%s'. Must be an integer" % \
+                        "Invalid value for height: '%s'. Must be an integer" %
                         entry.get_text())
                     return False
 
@@ -229,11 +223,11 @@ class PrefsDialog(dialog.T):
         self.path_list = Gtk.ListStore(
             GObject.TYPE_STRING)
         
-        path_treeview = Gtk.TreeView (model=self.path_list)
+        path_treeview = Gtk.TreeView(model=self.path_list)
 
-        renderer = Gtk.CellRendererText ()
-        column = Gtk.TreeViewColumn (_('_Directory'), renderer, text=0)
-        path_treeview.append_column (column)
+        renderer = Gtk.CellRendererText()
+        column = Gtk.TreeViewColumn(_('_Directory'), renderer, text=0)
+        path_treeview.append_column(column)
         path_treeview.set_headers_visible(False)
         
         paths = self.prefs.get_list(section_name)
@@ -241,7 +235,7 @@ class PrefsDialog(dialog.T):
             iter = self.path_list.append()
             self.path_list.set(iter,0,path)
 
-        return path_treeview 
+        return path_treeview
 
     def update_prefs(self,name, model):
         list = []
@@ -259,7 +253,7 @@ class PrefsDialog(dialog.T):
         if result == Gtk.ResponseType.OK:
             path = self.dirchooser.get_filename()
 
-            model = pathlist.get_model() 
+            model = pathlist.get_model()
             iter = model.append()
             
             model.set(iter,0,path)
@@ -299,10 +293,10 @@ class PrefsDialog(dialog.T):
         table.attach(flags_label,0,1,1,2,0,0,2,2)
         flags_label.set_mnemonic_widget(entry)
 
-        sw = Gtk.ScrolledWindow ()
-        sw.set_shadow_type (Gtk.ShadowType.ETCHED_IN)
-        sw.set_policy (Gtk.PolicyType.NEVER,
-                       Gtk.PolicyType.AUTOMATIC)
+        sw = Gtk.ScrolledWindow()
+        sw.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        sw.set_policy(Gtk.PolicyType.NEVER,
+                      Gtk.PolicyType.AUTOMATIC)
 
         form_path_section = "formula_path"
 
@@ -325,8 +319,7 @@ class PrefsDialog(dialog.T):
         remove_button = Gtk.Button.new_from_stock(Gtk.STOCK_REMOVE)
         remove_button.connect('clicked', self.remove_dir, form_path_section, pathlist)
         table.attach(remove_button,0,1,4,5,Gtk.AttachOptions.EXPAND | Gtk.AttachOptions.FILL, 0, 2, 2)
-        
-        
+
     def create_helper_options_page(self):
         table = Gtk.Table(n_rows=5,n_columns=2,homogeneous=False)
         label = Gtk.Label(label=_("_Helpers"))
@@ -454,4 +447,3 @@ class PrefsDialog(dialog.T):
         aalabel.set_use_underline(True)
         aalabel.set_mnemonic_widget(optMenu)
         table.attach(aalabel,0,1,5,6,0,0,2,2)
-        

--- a/fract4dgui/renderqueue.py
+++ b/fract4dgui/renderqueue.py
@@ -4,12 +4,9 @@
 
 import copy
 
-from gi.repository import GObject
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject
 
-from . import gtkfractal
-from . import dialog
-from . import preferences
+from . import dialog, gtkfractal, preferences
 
 class QueueEntry:
     def __init__(self, f, name, w, h):
@@ -43,7 +40,7 @@ class T(GObject.GObject):
         self.emit('changed')
         
     def start(self):
-        if self.current == None:
+        if self.current is None:
             next(self)
 
     def empty(self):
@@ -99,9 +96,9 @@ class QueueDialog(dialog.T):
         
         self.controls = Gtk.VBox()
         self.store = Gtk.ListStore(
-            GObject.TYPE_STRING, # name
-            GObject.TYPE_STRING, # size
-            GObject.TYPE_FLOAT, # % complete
+            str, # name
+            str, # size
+            float # % complete
             )
 
         self.view = Gtk.TreeView.new_with_model(self.store)
@@ -128,4 +125,3 @@ class QueueDialog(dialog.T):
         iter = self.store.get_iter_first()
         if iter:
             self.store.set_value(iter,2,progress)
-    

--- a/fract4dgui/renderqueue.py
+++ b/fract4dgui/renderqueue.py
@@ -78,34 +78,21 @@ class T(GObject.GObject):
 # explain our existence to GTK's object system
 GObject.type_register(T)
 
-def show(parent, alt_parent, f):
-    QueueDialog.show(parent, alt_parent, f)
-
-instance = T()
-
 class CellRendererProgress(Gtk.CellRendererProgress):
     def __init__(self):
         Gtk.CellRendererProgress.__init__(self)
         self.set_property("text", "Progress")
 
 class QueueDialog(dialog.T):
-    def show(parent, alt_parent, f):
-        dialog.T.reveal(QueueDialog,True, parent, alt_parent, f)
-            
-    show = staticmethod(show)
-
-    def __init__(self, main_window, f):
+    def __init__(self, main_window, f, renderQueue):
         dialog.T.__init__(
             self,
             _("Render Queue"),
             main_window,
-            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True
+            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
         )
 
-        self.main_window = main_window
-
-        self.q = instance
+        self.q = renderQueue
 
         self.q.connect('changed', self.onQueueChanged)
         self.q.connect('progress-changed', self.onProgressChanged)
@@ -130,6 +117,7 @@ class QueueDialog(dialog.T):
         
         self.controls.add(self.view)
         self.vbox.add(self.controls)
+        self.vbox.show_all()
 
     def onQueueChanged(self,q):
         self.store.clear()

--- a/fract4dgui/settings.py
+++ b/fract4dgui/settings.py
@@ -14,30 +14,20 @@ from .table import Table
 from fract4d import browser_model
 from fract4d.fc import FormulaTypes
 
-def show_settings(parent,alt_parent, f,dialog_mode):
-    SettingsDialog.show(parent,alt_parent, f,dialog_mode)
-
-class SettingsDialog(dialog.T):
-    def show(parent, alt_parent, f,dialog_mode):
-        dialog.T.reveal(SettingsDialog,dialog_mode, parent, alt_parent, f)
-            
-    show = staticmethod(show)
-    
+class SettingsPane(Gtk.Box):
     def __init__(self, main_window, f):
-        dialog.T.__init__(
-            self,
-            _("Fractal Settings"),
-            main_window,
-            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
-            destroy_with_parent=True)
+        Gtk.Box.__init__(self)
+        self.set_orientation(Gtk.Orientation.VERTICAL)
 
         self.main_window = main_window
         self.f = f
+        
+        label_box = dialog.make_label_box(self, _("Fractal Settings"))
         self.notebook = Gtk.Notebook()
         self.notebook.set_name("settings_notebook")
-        self.controls = Gtk.VBox()
-        self.controls.pack_start(self.notebook, True, True, 0)
-        self.vbox.pack_start(self.controls, True, True, 0)
+        self.pack_start(label_box, False, False, 0)
+        self.pack_start(self.notebook, True, True, 0)
+        
         self.tables = [None,None,None,None]
         self.selected_transform = None
         
@@ -48,6 +38,8 @@ class SettingsDialog(dialog.T):
         self.create_general_page()
         self.create_location_page()
         self.create_colors_page()
+
+        self.notebook.show_all()
 
     def gradarea_mousedown(self, widget, event):
         pass
@@ -549,7 +541,7 @@ class SettingsDialog(dialog.T):
         d = hig.ErrorAlert(
             primary=message,
             secondary=secondary_message,
-            parent=self.main_window)
+            parent=self.main_window.window)
         d.run()
         d.destroy()
 

--- a/fract4dgui/settings.py
+++ b/fract4dgui/settings.py
@@ -688,7 +688,9 @@ class SettingsPane(Gtk.Box):
                 self.update_all_widgets(fractal,widget) # recurse
 
     def show_browser(self,button,type):
-        browser.show(self.main_window, self.f, type)
+        dialog = browser.BrowserDialog(self.main_window, self.f, type)
+        dialog.run()
+        dialog.destroy()
         
     def create_param_entry(self,table, row, text, param):
         label = Gtk.Label(label=text)

--- a/fract4dgui/test_browser.py
+++ b/fract4dgui/test_browser.py
@@ -20,14 +20,17 @@ if sys.path[1] != "..": sys.path.insert(1, "..")
 from fract4d import fc, fractal, browser_model
 from fract4dgui import browser
 
+class MockMainWindow:
+    def __init__(self):
+        self.window = None
+        self.compiler = fc.Compiler()
+        self.compiler.add_func_path("../formulas")
+        self.compiler.add_func_path("../fract4d")
 
 class Test(unittest.TestCase):
     def setUp(self):
-        self.compiler = fc.instance
-        self.compiler.add_func_path("../formulas")
-        self.compiler.add_func_path("../fract4d")
-        
-        self.f = fractal.T(self.compiler,self)
+        self.mainWindow = MockMainWindow()
+        self.f = fractal.T(self.mainWindow.compiler,self)
     
     def tearDown(self):
         browser._model = None
@@ -40,17 +43,17 @@ class Test(unittest.TestCase):
             Gtk.main_quit()
 
     def testCreate(self):        
-        b = browser.BrowserDialog(None,self.f)
+        b = browser.BrowserDialog(self.mainWindow, self.f)
         self.assertNotEqual(b,None)
 
-    def testLoadFormula(self):
-        b = browser.BrowserDialog(None,self.f)
+    def testSetFormula(self):
+        b = browser.BrowserDialog(self.mainWindow, self.f)
         b.set_file('gf4d.frm')
         b.set_formula('Newton')
         self.assertEqual(b.ir.errors,[])
 
     def testBadFormula(self):
-        b = browser.BrowserDialog(None,self.f)
+        b = browser.BrowserDialog(self.mainWindow, self.f)
         #print b.model.compiler.path_lists[0]
         b.set_file('test.frm')
         b.set_formula('parse_error')
@@ -63,13 +66,20 @@ class Test(unittest.TestCase):
         self.assertNotEqual(all_text,"")
         self.assertEqual(all_text[0:7],"Errors:")
 
-    def test_update(self):
-        b = browser.BrowserDialog(None,self.f)
-        b = browser.update(None)
-        m = browser_model.instance
-        self.assertEqual(None, m.current.fname)
-        self.assertEqual(None, m.current.formula)
+    def test_init(self):
+        b = browser.BrowserDialog(self.mainWindow, self.f)
+        m = b.model
+        self.assertEqual('gf4d.frm', m.current.fname)
+        self.assertEqual('Mandelbrot', m.current.formula)
 
+    def testLoadFormula(self):
+        b = browser.BrowserDialog(self.mainWindow, self.f)
+        m = b.model
+        # load good formula file
+        b.load_file("../formulas/fractint.cfrm")
+        self.assertEqual('fractint.cfrm', m.current.fname, "failed to load formula")
+        #load missing file
+        self.assertRaises(OSError, b.load_file, "/no_such_dir/wibble.frm")
 
 def suite():
     return unittest.makeSuite(Test,'test')

--- a/fract4dgui/test_director.py
+++ b/fract4dgui/test_director.py
@@ -2,10 +2,9 @@
 
 # unit tests for renderqueue module
 
-import unittest
-import sys
 import os
-import subprocess
+import sys
+import unittest
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -17,8 +16,7 @@ gettext.install('gnofract4d')
 
 if sys.path[1] != "..": sys.path.insert(1, "..")
 from fract4dgui import director, PNGGen, hig
-
-from fract4d import fractal, image, fc, animation
+from fract4d import fractal, fc, animation
 
 g_comp = fc.Compiler()
 g_comp.add_func_path("../fract4d")
@@ -141,7 +139,7 @@ class Test(unittest.TestCase):
         pg.generate_png()
         
         dd.destroy()
-        
+
 def suite():
     return unittest.makeSuite(Test,'test')
 

--- a/fract4dgui/test_director.py
+++ b/fract4dgui/test_director.py
@@ -137,7 +137,7 @@ class Test(unittest.TestCase):
     def testPNGGen(self):
         f = fractal.T(g_comp)
         dd= director.DirectorDialog(None,f,"")
-        pg = PNGGen.PNGGeneration(dd.animation,g_comp)
+        pg = PNGGen.PNGGeneration(dd.animation,g_comp,dd)
         pg.generate_png()
         
         dd.destroy()

--- a/fract4dgui/test_director.py
+++ b/fract4dgui/test_director.py
@@ -62,8 +62,8 @@ class Test(unittest.TestCase):
             
         self.assertEqual(True,os.path.exists("./image_0000000.png"))
         self.assertEqual(True,os.path.exists("./image_0000001.png"))
-        if dd.transpath != None:
-            # only check for video if transcode is installed
+        if dd.converterpath:
+            # only check for video if video converter is installed
             self.assertEqual(True,os.path.exists("video.avi"))
 
         dd.destroy()

--- a/fract4dgui/test_director.py
+++ b/fract4dgui/test_director.py
@@ -47,7 +47,7 @@ class Test(unittest.TestCase):
 
         f = fractal.T(g_comp)
         dd=director.DirectorDialog(None,f,"")
-        dd.show(None,None,f,True,"")
+        dd.show()
         dd.animation.set_png_dir("./")
         dd.animation.set_fct_enabled(False)
         dd.animation.add_keyframe("../testdata/director1.fct",1,10,animation.INT_LOG)

--- a/fract4dgui/test_fourway.py
+++ b/fract4dgui/test_fourway.py
@@ -38,7 +38,7 @@ class Test(unittest.TestCase):
     def testAddToWindow(self):
         w = Gtk.Window()
         f = fourway.T("wibble")
-        w.add(f.widget)
+        w.add(f)
         w.show()
         Gtk.main_iteration()
 

--- a/fract4dgui/test_main_window.py
+++ b/fract4dgui/test_main_window.py
@@ -9,10 +9,14 @@ import os
 import sys
 import random
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
+
 import gettext
 os.environ.setdefault('LANG', 'en')
 gettext.install('gnofract4d')
+
 if sys.path[1] != "..": sys.path.insert(1, "..")
 
 from fract4d import fractal

--- a/fract4dgui/test_main_window.py
+++ b/fract4dgui/test_main_window.py
@@ -129,7 +129,6 @@ class Test(unittest.TestCase):
         self.assertEqual(fct1, fct2)
         
     def testDialogs(self):
-        self.mw.director(None,None)
         self.mw.settings(None,None)
         self.mw.contents(None,None)
         self.mw.painter(None,None)

--- a/fract4dgui/test_main_window.py
+++ b/fract4dgui/test_main_window.py
@@ -116,17 +116,6 @@ class Test(unittest.TestCase):
         finally:
             if os.path.exists("mygood.png"):
                 os.remove("mygood.png")
-            
-    def testLoadFormula(self):
-        # load good formula file
-        result = self.mw.load_formula("../formulas/fractint.cfrm")
-        self.assertEqual(result, True, "failed to load formula")
-
-        #load missing file
-        result = self.mw.load_formula("/no_such_dir/wibble.frm")
-        self.assertEqual(result, False, "load bad formula succeeded")
-        self.assertEqual(
-            self.mw.errors[0][0], "Error opening /no_such_dir/wibble.frm")
 
     def testPreview(self):
         'Check for problem where preview differs from main image'
@@ -143,7 +132,6 @@ class Test(unittest.TestCase):
         self.mw.director(None,None)
         self.mw.settings(None,None)
         self.mw.contents(None,None)
-        self.mw.browser(None,None)
         self.mw.painter(None,None)
         
     def testFileDialogs(self):

--- a/fract4dgui/test_main_window.py
+++ b/fract4dgui/test_main_window.py
@@ -142,8 +142,6 @@ class Test(unittest.TestCase):
     def testDialogs(self):
         self.mw.director(None,None)
         self.mw.settings(None,None)
-        self.mw.preferences(None,None)
-        self.mw.autozoom(None,None)
         self.mw.contents(None,None)
         self.mw.browser(None,None)
         self.mw.painter(None,None)

--- a/fract4dgui/test_painter.py
+++ b/fract4dgui/test_painter.py
@@ -8,10 +8,14 @@ import math
 import os
 import sys
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
+
 import gettext
 os.environ.setdefault('LANG', 'en')
 gettext.install('gnofract4d')
+
 if sys.path[1] != "..": sys.path.insert(1, "..")
 
 from fract4d import fc, fractal

--- a/fract4dgui/test_preferences.py
+++ b/fract4dgui/test_preferences.py
@@ -6,6 +6,9 @@ import unittest
 import sys
 import os
 
+import gi
+gi.require_version('Gtk', '3.0')
+
 if sys.path[1] != "..": sys.path.insert(1, "..")
 from fract4dgui import preferences
 from fract4d import fractconfig

--- a/fract4dgui/test_renderqueue.py
+++ b/fract4dgui/test_renderqueue.py
@@ -66,13 +66,14 @@ class Test(unittest.TestCase):
 
     def testQueueDialog(self):
         f = fractal.T(g_comp)
-        renderqueue.show(None,None,f)
-        rq = renderqueue.instance
+        rq = renderqueue.T()
         rq.add(f,"foo.png",124,276)
         rq.add(f,"foo2.png",204,153)
         rq.add(f,"foo3.png",80,40)
         rq.connect('done', self.quitloop)
         rq.start()
+        d = renderqueue.QueueDialog(None, f, rq)
+        d.show()
         self.wait()
         os.remove("foo.png"); os.remove("foo2.png"); os.remove("foo3.png")
 

--- a/fract4dgui/test_settings.py
+++ b/fract4dgui/test_settings.py
@@ -29,7 +29,7 @@ class Test(unittest.TestCase):
         self.compiler.add_func_path("../fract4d")
         
         self.f = gtkfractal.T(self.compiler)
-        self.settings = settings.SettingsDialog(None,self.f)
+        self.settings = settings.SettingsPane(None,self.f)
         
     def tearDown(self):
         pass


### PR DESCRIPTION
This is on top of #24.

Hopefully fixes #7, transcode option `--use_rgb` is not supported in 1.1.7 and problems with the image list too. As latest transcode is I believe 7 years old and looks like it won't work with ImageMagick 7 I've changed the code to use ffmpeg direct. The video is set to webm format.

I removed the threading and used GLib.spawn_async instead. As well as simplifying the code a plus is that it can now detect success/failure and the user can cancel generation. I haven't implemented progress reporting though.

Added the ability to type the video filename straight into the Directory dialog.

Fixed a bug in that all the settings in the Director dialog were set to 0 on opening.

Usual tidy up and fix as many deprecation warnings as possible.

This does generate video but worth checking it is as expected.

The ffmpeg file list format can support durations for each listed frame so some savings may be possible by using that.




