### PR TITLE
use universal location for docbook.xsl

### DIFF
--- a/createdocs.py
+++ b/createdocs.py
@@ -24,7 +24,7 @@ def create_stdlib_docs():
 
         # create HTML version of docs for them as don't have yelp
         os.chdir("doc/gnofract4d-manual/C")        
-        retval = os.system("xsltproc --output gnofract4d-manual.html --stringparam html.stylesheet docbook.css gnofract4d.xsl gnofract4d-manual.xml")
+        retval = os.system("xsltproc --nonet --output gnofract4d-manual.html --stringparam html.stylesheet docbook.css gnofract4d.xsl gnofract4d-manual.xml")
         if retval != 0:
             raise Exception("error processing xslt")
     except Exception as err:

--- a/doc/gnofract4d-manual/C/gnofract4d.xsl
+++ b/doc/gnofract4d-manual/C/gnofract4d.xsl
@@ -3,7 +3,7 @@
 
 
 <!-- Imports the DocBook HTML chunking stylesheets. --> 
-<xsl:import href="/usr/share/sgml/docbook/stylesheet/xsl/nwalsh/xhtml/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/xhtml/docbook.xsl"/>
 <xsl:template match="guimenuitem">
   <span class="guimenuitem"><xsl:call-template name="inline.charseq"/></span>
 </xsl:template>


### PR DESCRIPTION
xsltproc will use the system catalog to find the local path.
Pass --nonet option to ensure the Internet is not used.

---

On Gentoo I was doing:

```
 <!-- Imports the DocBook HTML chunking stylesheets. --> 
-<xsl:import href="/usr/share/sgml/docbook/stylesheet/xsl/nwalsh/xhtml/docbook.xsl"/>
+<xsl:import href="/usr/share/sgml/docbook/xsl-stylesheets/xhtml/docbook.xsl"/>
 <xsl:template match="guimenuitem">
   <span class="guimenuitem"><xsl:call-template name="inline.charseq"/></span>
 </xsl:template>
```

Ubuntu is using a symlink, but this I believe would work everywhere (tested on Gentoo and Ubuntu) that has XML catalogs setup.