### PR TITLE
Fix Python deprecation warnings

### DIFF
--- a/fract4d/test_symbol.py
+++ b/fract4d/test_symbol.py
@@ -2,7 +2,7 @@
 
 # test symbol table implementation
 
-import collections
+import collections.abc
 import unittest
 import copy
 import sys
@@ -286,7 +286,7 @@ class SymbolTest(unittest.TestCase):
         
     def assertIsValidFunc(self,val):
         specialFuncs = [ "noteq", "eq" ]
-        self.assertTrue(isinstance(val.genFunc, collections.Callable) or
+        self.assertTrue(isinstance(val.genFunc, collections.abc.Callable) or
                         val.genFunc == None or
                         specialFuncs.count(val.cname) > 0, val.cname)
 

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ if have_gmp:
 def get_files(dir,ext):
     return [ os.path.join(dir,x) for x in os.listdir(dir) if x.endswith(ext)]
 
-so_extension = distutils.sysconfig.get_config_var("SO")
+so_extension = distutils.sysconfig.get_config_var("EXT_SUFFIX")
 
 with open("fract4d/c/cmap_name.h", "w") as fh:
 	fh.write("""


### PR DESCRIPTION
Descriptions in the commits. New code present since at least Python 3.3.

Just silencing noise for now, although the setup.py one will be needed for Python 3.8! (All the tests are passing for me with Python 3.7).
