### PR TITLE
Fix fract4d/test_image.py

### DIFF
--- a/fract4d/test_image.py
+++ b/fract4d/test_image.py
@@ -210,9 +210,8 @@ class Test(testbase.ClassSetup):
             self.saveAndCheck("no_such_dir/test.png","PNG")
             self.fail("No exception thrown")
         except FileNotFoundError as err:
-            self.assertEqual(
-                str(err),
-                "[Errno 2] No such file or directory: 'no_such_dir/test.png'")
+            self.assertTrue(str(err).find('[Errno 2]') is not -1)
+            self.assertTrue(str(err).find('no_such_dir/test.png') is not -1)
 
     def testResize(self):
         im = image.T(10,20)


### PR DESCRIPTION
The test provokes an error and checks the message.
If you don't have the system in english the test fails.
Now the test only checks part of the message text so the
language shouldn't be a problem.