### PR TITLE
Fix macos compatibility

### DIFF
--- a/README
+++ b/README
@@ -53,12 +53,16 @@ o Pkg-Config
 
 On Ubuntu, these can be installed with:
 
-sudo apt-get install libpng-dev libjpeg-dev python3-dev gtk3.0 cairo python3-cairo python3-gi-cairo pkg-config 
+sudo apt-get install libpng-dev libjpeg-dev python3-dev gtk3.0 cairo python3-cairo python3-gi-cairo pkg-config
 
 If you're not sure if you have these or not, just try running
 "./setup.py build" and see if it complains.
 
 If FFmpeg is installed it will be possible to create videos.
+
+On MacOS, you can install the dependencies using brew:
+
+brew install librsvg python3 pkg-config cairo gtk+3 pygobject3 py3cairo libpng jpeg
 
 Testing
 =======
@@ -70,3 +74,5 @@ pytest fract4d/test_absyn.py
 
 Optionally, install tox and test with all supported Python versions by running:
 tox
+
+On MacOS you might find an error regarding the number of opened files, you can increase the system limit with `ulimit -Sn 10000`

--- a/fract4d/fractconfig.py
+++ b/fract4d/fractconfig.py
@@ -16,7 +16,7 @@ class T(configparser.ConfigParser):
             ("compiler",
              OrderedDict((
                          ("name", comp),
-                         ("options", T.get_default_compiler_options()),
+                         ("options", self.get_default_compiler_options()),
                          ))
              ),
             ("optimize",
@@ -41,9 +41,9 @@ class T(configparser.ConfigParser):
              ),
             ("helpers",
              OrderedDict((
-                         ("editor", T.get_default_editor()),
-                         ("mailer", T.get_default_mailer()),
-                         ("browser", T.get_default_browser()),
+                         ("editor", self.get_default_editor()),
+                         ("mailer", self.get_default_mailer()),
+                         ("browser", self.get_default_browser()),
                          ))
              ),
             ("general",
@@ -146,20 +146,16 @@ class T(configparser.ConfigParser):
         #print "missing resource %s" % full_name
         return full_name
 
-    @staticmethod
-    def get_default_editor():
+    def get_default_editor(self):
         return "emacs"
 
-    @staticmethod
-    def get_default_mailer():
+    def get_default_mailer(self):
         return "evolution %s"
 
-    @staticmethod
-    def get_default_browser():
+    def get_default_browser(self):
         return "firefox %s"
 
-    @staticmethod
-    def get_default_compiler_options():
+    def get_default_compiler_options(self):
         # appears to work for most unixes
         return "-fPIC -DPIC -D_REENTRANT -O2 -shared -ffast-math"
 
@@ -252,22 +248,18 @@ class DarwinConfig(T):
     def __init__(self,file):
         T.__init__(self,file)
 
-    @staticmethod
-    def get_default_editor():
+    def get_default_editor(self):
         # edit file in TextPad
         return "open -e"
 
-    @staticmethod
-    def get_default_mailer():
+    def get_default_mailer(self):
         # create message in default mail app
         return "open %s"
 
-    @staticmethod
-    def get_default_browser():
+    def get_default_browser(self):
         return "open %s"
 
-    @staticmethod
-    def get_default_compiler_options():
+    def get_default_compiler_options(self):
         return "-fPIC -DPIC -D_REENTRANT -O2 -dynamiclib -flat_namespace -undefined suppress -ffast-math"
 
 def userConfig():

--- a/fract4d/test_codegen.py
+++ b/fract4d/test_codegen.py
@@ -232,7 +232,11 @@ int main()
         cFile.flush()
 
         oFileName = str(Path(cFile.name).with_suffix(".so"))
-        cmd = "gcc -Wall -fPIC -DPIC -shared %s -o %s -lm" % (cFile.name, oFileName)
+        import sys
+        if sys.platform[:6] == "darwin":
+            cmd = "gcc -Wall -fPIC -DPIC -shared %s -o %s -lm -flat_namespace -undefined suppress" % (cFile.name, oFileName)
+        else:
+            cmd = "gcc -Wall -fPIC -DPIC -shared %s -o %s -lm" % (cFile.name, oFileName)
         status, output = subprocess.getstatusoutput(cmd)
         self.assertEqual(status,0,"C error:\n%s\nProgram:\n%s\n" % \
                          ( output,c_code))
@@ -1696,8 +1700,8 @@ TileMandel {; Terren Suydam (terren@io.com), 1996
         return "printf(\"%s = %%d\\n\", f%s);" % (name,name)
 
     def inspect_complex(self,name,prefix="f"):
-        return "printf(\"%s = (%%g,%%g)\\n\", %s%s_re, %s%s_im);" % \
-               (name,prefix,name,prefix,name)
+        return "printf(\"%s = (%%g,%%g)\\n\", isnan(%s%s_re) ? NAN : %s%s_re, isnan(%s%s_im) ? NAN : %s%s_im);" % \
+               (name,prefix,name,prefix,name,prefix,name,prefix,name)
 
     def inspect_hyper(self,name,prefix="f"):
         return ("printf(\"%s = (%%g,%%g,%%g,%%g)\\n\"," +
@@ -1751,7 +1755,7 @@ TileMandel {; Terren Suydam (terren@io.com), 1996
         tests = self.manufacture_tests("cotan",mycotan)
 
         # CONSIDER: Python 2.7 thinks this cotan(0) is -nan,-nan, older versions think (nan,nan)
-        tests[0][2] = "(-nan,-nan)"
+        tests[0][2] = "(nan,nan)"
 
         # CONSIDER: comes out as -0,1.31304 in python, but +0 in C++ and gf4d
         # think Python's probably in error, but not 100% sure
@@ -1768,7 +1772,7 @@ TileMandel {; Terren Suydam (terren@io.com), 1996
         #print tests
         
         # CONSIDER: Python 2.7 thinks this cotanh(0) is -nan,-nan, older versions think (nan,nan)
-        tests[0][2] = "(-nan,-nan)"
+        tests[0][2] = "(nan,nan)"
 
         return tests
         
@@ -1797,8 +1801,8 @@ TileMandel {; Terren Suydam (terren@io.com), 1996
         tests = self.manufacture_tests("atan",cmath.atan)
 
         #print("before", tests)
-        tests[1][2] = "(-nan,-nan)"
-        tests[6][2] = "(-nan,-inf)" # not really sure who's right on this
+        tests[1][2] = "(nan,nan)"
+        tests[6][2] = "(nan,-inf)" # not really sure who's right on this
         #print("after", tests)
         return tests
 
@@ -1899,7 +1903,7 @@ TileMandel {; Terren Suydam (terren@io.com), 1996
             [ "l = (log(1),log(3))", "l", self.predict(math.log,1,3)],
             [ "ex = (exp(1),exp(2))","ex", self.predict(math.exp,1,2)],
             [ "pow0a = (2^2, 9^0.5)", "pow0a", "(4,3)"],
-            [ "pow0b = ((-1)^0.5,(-1)^2)", "pow0b", "(-nan,1)"], 
+            [ "pow0b = ((-1)^0.5,(-1)^2)", "pow0b", "(nan,1)"],
             [ "pow1 = (1,0)^2","pow1", "(1,0)"],
             [ "pow2 = (-2,-3)^7.5","pow2","(-13320.5,6986.17)"],
             [ "pow3 = (-2,-3)^(1.5,-3.1)","pow3","(0.00507248,-0.00681128)"],

--- a/fract4d/test_fc.py
+++ b/fract4d/test_fc.py
@@ -236,8 +236,8 @@ bailout: abs(real(z)) > 2.0 || abs(imag(z)) > 2.0
         compiler = fc.Compiler(Test.userConfig)
         self.assertNotEqual(None, compiler)
         self.assertEqual(
-            compiler.flags, fractconfig.T("").get("compiler", "options"))
-            
+            compiler.flags, Test.userConfig.get("compiler", "options"))
+
     def testAllFormulasCompile(self):
         'Go through every formula and check for errors'
         for filename in Test.g_comp.find_formula_files():

--- a/fract4d/testbase.py
+++ b/fract4d/testbase.py
@@ -226,7 +226,13 @@ class ClassSetup(TestBase):
     @classmethod
     def setUpClass(cls):
         cls.tmpdir = tempfile.TemporaryDirectory(prefix="fract4d_")
-        cls.userConfig = fractconfig.T("")
+
+        import sys
+        if sys.platform[:6] == "darwin":
+            cls.userConfig = fractconfig.DarwinConfig("")
+        else:
+            cls.userConfig = fractconfig.T("")
+
         cls.userConfig.set("general","cache_dir",
                            os.path.join(cls.tmpdir.name,"gnofract4d-cache"))
         cls.userConfig["formula_path"].clear()

--- a/fract4dgui/testgui.py
+++ b/fract4dgui/testgui.py
@@ -20,7 +20,13 @@ class TestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tmpdir = tempfile.TemporaryDirectory(prefix="fract4d_")
-        cls.userConfig = fractconfig.T("")
+
+        import sys
+        if sys.platform[:6] == "darwin":
+            cls.userConfig = fractconfig.DarwinConfig("")
+        else:
+            cls.userConfig = fractconfig.T("")
+
         cls.userConfig.set("general","cache_dir", os.path.join(cls.tmpdir.name,
                            "gnofract4d-cache"))
         cls.userConfig["formula_path"].clear()


### PR DESCRIPTION
There were some errors on fractconfig implemenation preventing the compiler to get the right flags for MacOS system.
Also some tests wasn't checking the environment to create the userConfig object.
Finally there was a problem with codegen (a module used for the compiler) test: it was looking for "-nan" values but, depending on the system compiler, those values could be "nan" or "-nan".